### PR TITLE
don't do resid draw for now

### DIFF
--- a/subsystems/Makefile.am
+++ b/subsystems/Makefile.am
@@ -13,4 +13,5 @@ SUBDIRS = \
   mvtx \
   siliconseeds \
   tpcseeds \
+  tpc \
   vertex

--- a/subsystems/tpc/TPCDraw.cc
+++ b/subsystems/tpc/TPCDraw.cc
@@ -67,11 +67,13 @@ int TPCDraw::Draw(const std::string &what)
     iret += DrawRegionInfo();
     idraw++;
   }
+  /*
   if (what == "ALL" || what == "RESID")
   {
     iret += DrawResidInfo();
     idraw++;
   }
+  */
   if (!idraw)
   {
     std::cout << " Unimplemented Drawing option: " << what << std::endl;


### PR DESCRIPTION
Inadvertently removed tpc from makefile, and skip resid drawing for now so that other tpc cluster histos draw