### PR TITLE
Updated OfflineQAKSTest module to allow for user to specify option

### DIFF
--- a/subsystems/siliconseeds/OfflineQAKSTest.h
+++ b/subsystems/siliconseeds/OfflineQAKSTest.h
@@ -16,13 +16,20 @@ class OfflineQAKSTest
    OfflineQAKSTest(const std::string & inputfile, const std::string & goodrunfile = "");
    ~OfflineQAKSTest();
 
-   TH1D * GenKSTestSummary();
+   TH1D * GenKSTestSummary(const char * option = "");
    void AddHistogramNames(const std::set<std::string> & names);
+   double GetHistoScore(const std::string &name, const char * option = "");
+
+    void Verbosity(unsigned int v) { m_verbosity = v; }
+    unsigned int Verbosity() const { return m_verbosity; }
 
  private:
 
    std::string m_inputfile{""};
    std::string m_goodrunfile{""};
+
+   
+   unsigned int m_verbosity{0};
 
    TFile * m_inputfileptr{nullptr};
    TFile * m_goodrunfileptr{nullptr};
@@ -30,7 +37,7 @@ class OfflineQAKSTest
    std::set<std::string> m_histogram_names{};
 
    template <typename T>
-   double KSTest(T *h1, T *h2, const char * options = "N");
+   double KSTest(T *h1, T *h2, const char * options = "");
   
 };
 

--- a/subsystems/siliconseeds/macros/draw_siliconseeds.C
+++ b/subsystems/siliconseeds/macros/draw_siliconseeds.C
@@ -45,7 +45,7 @@ void draw_siliconseeds(const std::string &rootfile) {
   TH1D *hm_kssumary = qakstest->GenKSTestSummary();
 
   SiSeedsGoodRunChecker* ch = new SiSeedsGoodRunChecker();
-  ch->SetKSTestSummary(hm_kssumary);
+  ch->SetKSTestSummary(hm_kssumary, "");
   bool siseeds_isgood = ch->SiSeedsGoodRun();
   TCanvas* siseeds_summ = ch->SiSeedsMakeSummary(cl->ExtractRunNumber(rootfile), siseeds_isgood); 
   ex->SetSiSeedsSummary(cl->ExtractRunNumber(rootfile), siseeds_summ);


### PR DESCRIPTION
- Updated `OfflineQAKSTest` module to allow for user specified option when running KS test.
- Changed default option from "D" to  "". 
- Added check for -1 (failed test) to output histogram. 
- Changed TProfile2D KSTest to not have to project to TH2D before doing the test.