### PR TITLE
Improvements to TPC Offline QA Drawing Modules

### DIFF
--- a/subsystems/tpcrawhit/TPCRawHitDraw.h
+++ b/subsystems/tpcrawhit/TPCRawHitDraw.h
@@ -27,9 +27,9 @@ class TPCRawHitDraw : public QADraw
   int MakeCanvas(const std::string &name, int num);
   int DrawSectorInfo();
   int DrawOnlMon();
-  TCanvas *TC[18]{};
-  TPad *transparent[18]{};
-  TPad *Pad[18][6]{};
+  TCanvas *TC[25]{};
+  TPad *transparent[25]{};
+  TPad *Pad[25][6]{};
   const char *histprefix;
 };
 

--- a/subsystems/tpcsil/TPCSilDraw.cc
+++ b/subsystems/tpcsil/TPCSilDraw.cc
@@ -238,7 +238,7 @@ int TPCSilDraw::DrawCutHistograms()
   std::cout << "TPCSil DrawCutHistograms() Beginning" << std::endl;
   QADrawClient *cl = QADrawClient::instance();
 
-  std::vector<std::string> cutNames = {"_xyCut", "_etaCut", "_phiCut"};
+  std::vector<std::string> cutNames = {"_xyCut", "_etaCut", "_phiCut", "North", "South", "NorthAllCuts", "SouthAllCuts"};
 
   int i = 2;
   for (const std::string& name : cutNames)
@@ -351,7 +351,7 @@ int TPCSilDraw::MakeHtml(const std::string &what)
   }
   if (what == "ALL" || what == "CUTS")
   {
-    std::vector<std::string> cutNames = {"_xyCut", "_etaCut", "_phiCut"};
+    std::vector<std::string> cutNames = {"_xyCut", "_etaCut", "_phiCut", "North", "South", "NorthAllCuts", "SouthAllCuts"};
     int i = 2;
     for (const std::string& name : cutNames)
     { 

--- a/subsystems/tpcsil/TPCSilDraw.h
+++ b/subsystems/tpcsil/TPCSilDraw.h
@@ -27,9 +27,9 @@ class TPCSilDraw : public QADraw
     int MakeCanvas(const std::string &name, int num);
     int DrawPositionInfo();
     int DrawCutHistograms();
-    TCanvas *TC[5]{};
-    TPad *transparent[5]{};
-    TPad *Pad[5][6]{};
+    TCanvas *TC[9]{};
+    TPad *transparent[9]{};
+    TPad *Pad[9][6]{};
     const char *histprefix;
 };
 


### PR DESCRIPTION
Adding new drawing capabilities to reflect the changes made in coresoftware PR 3117
- North/South separated TpcSiliconQA plots for no cuts and all cuts
- Laser/no laser separation of TpcRawHitsQA histograms and improvements to how hits are determined and included needed some rescaling of plot axes