### PR TITLE
Squash major bug in JetQA

### DIFF
--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -28,6 +28,7 @@ JetDraw::JetDraw(const std::string &name)
 : QADraw(name)
 {
   DBVarInit();
+  m_do_debug = false;
   m_constituent_prefix = "h_constituentsinjets";
   m_rho_prefix = "h_eventwiserho";
   m_kinematic_prefix = "h_jetkinematiccheck";
@@ -306,20 +307,20 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
   // Use resToDraw to select histograms or adjust drawing logic
   switch (resToDraw) {
   case R02:
-    std::cout << "Resolution R02" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R02" << std::endl;
     break;
   case R03:
-    std::cout << "Resolution R03" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R03" << std::endl;
     break;
   case R04:
-    std::cout << "Resolution R04" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R04" << std::endl;
     break;
   case R05:
-    std::cout << "Resolution R05" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R05" << std::endl;
     break;
   default:
     std::cerr << "Unknown resolution" << std::endl;
-    break;
+    return -1;
   }
 
   // for constituent hist names
@@ -540,20 +541,20 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
   // Use resToDraw to select histograms or adjust drawing logic
   switch (resToDraw) {
   case R02:
-    std::cout << "Resolution R02" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R02" << std::endl;
     break;
   case R03:
-    std::cout << "Resolution R03" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R03" << std::endl;
     break;
   case R04:
-    std::cout << "Resolution R04" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R04" << std::endl;
     break;
   case R05:
-    std::cout << "Resolution R05" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R05" << std::endl;
     break;
   default:
     std::cerr << "Unknown resolution" << std::endl;
-    break;
+    return -1;
   }
 
   // for kinematic hist names
@@ -695,20 +696,20 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
   // Use resToDraw to select histograms or adjust drawing logic                                                                           
   switch (resToDraw) {
   case R02:
-    std::cout << "Resolution R02" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R02" << std::endl;
     break;
   case R03:
-    std::cout << "Resolution R03" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R03" << std::endl;
     break;
   case R04:
-    std::cout << "Resolution R04" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R04" << std::endl;
     break;
   case R05:
-    std::cout << "Resolution R05" << std::endl;
+    if (m_do_debug) std::cout << "Resolution R05" << std::endl;
     break;
   default:
     std::cerr << "Unknown resolution" << std::endl;
-    break;
+    return -1;
   }
 
   // for seed hist names
@@ -909,6 +910,11 @@ void JetDraw::SetJetSummary(TCanvas* c)
    tr->cd();
    PrintRun.DrawText(0.5, 1., runstring.c_str());
    jetSummary->Update();
+}
+
+void JetDraw::SetDoDebug(const bool debug)
+{
+  m_do_debug = debug;
 }
 
 void JetDraw::myText(double x, double y, int color, const char *text, double tsize)

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -108,12 +108,6 @@ int JetDraw::Draw(const std::string &what)
      m_vecKineRun.push_back( {} );
      m_vecSeedRun.push_back( {} );
 
-     // and same for the pad vectors (incl. the rho pads)
-     m_vecRhoPad.push_back( {} );
-     m_vecCstPad.push_back( {} );
-     m_vecKinePad.push_back( {} );
-     m_vecSeedPad.push_back( {} );
-
      // draw rho plots
      if  (what == "ALL" || what == "RHO")
      {
@@ -124,11 +118,6 @@ int JetDraw::Draw(const std::string &what)
      // now loop over resolutions to draw
      for (uint32_t resToDraw : m_vecResToDraw)
      {
-
-       // add new column for reso.-depdent pad vectors
-       m_vecCstPad.back().push_back( {} );
-       m_vecKinePad.back().push_back( {} );
-       m_vecSeedPad.back().push_back( {} );
 
        // draw constituent plots
        if (what == "ALL" || what == "CONTSTITUENTS")

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -424,7 +424,6 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_ncstsvscalolayer->SetYTitle("Calo Layer");
     constituents_ncstsvscalolayer->SetZTitle("Counts");
     constituents_ncstsvscalolayer->DrawCopy("COLZ"); // 2D Histogram
-    gStyle->SetPalette(4, kBird);
     gPad->UseCurrentStyle();
     gPad->Update();
     gPad->SetRightMargin(0.15);
@@ -443,7 +442,6 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_efracjetvscalolayer->SetYTitle("Calo Layer");
     constituents_efracjetvscalolayer->SetZTitle("Counts");
     constituents_efracjetvscalolayer->DrawCopy("COLZ"); // 2D Histogram
-    gStyle->SetPalette(4, kBird);
     gPad->UseCurrentStyle();
     gPad->Update();
     gPad->SetRightMargin(0.15);
@@ -461,7 +459,6 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_efracjet_cemc->SetXTitle("Jet E fraction");
     constituents_efracjet_cemc->SetYTitle("Counts");
     constituents_efracjet_cemc->DrawCopy("HIST"); // 1D Histogram
-    gStyle->SetPalette(4, kBird);
     gPad->UseCurrentStyle();
     gPad->Update();
     gPad->SetRightMargin(0.15);
@@ -479,7 +476,6 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_efracjet_ihcal->SetXTitle("Jet E Fraction");
     constituents_efracjet_ihcal->SetYTitle("Counts");
     constituents_efracjet_ihcal->DrawCopy("HIST"); // 1D Histogram
-    gStyle->SetPalette(4, kBird);
     gPad->UseCurrentStyle();
     gPad->Update();
     gPad->SetRightMargin(0.15);
@@ -497,7 +493,6 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_efracjet_ohcal->SetXTitle("Jet E Fraction");
     constituents_efracjet_ohcal->SetYTitle("Counts");
     constituents_efracjet_ohcal->DrawCopy("HIST");  // 1D Histogram
-    gStyle->SetPalette(4, kBird);
     gPad->UseCurrentStyle();
     gPad->Update();
     gPad->SetRightMargin(0.15);
@@ -589,7 +584,6 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     // jetkinematiccheck_etavsphi->GetXaxis()->SetNdivisions(505);
     // jetkinematiccheck_etavsphi->GetXaxis()->SetRangeUser(-1, 15);
     jetkinematiccheck_etavsphi->DrawCopy("COLZ");  // 2D Histogram
-    gStyle->SetPalette(4, kBird);
     gPad->UseCurrentStyle();
     gPad->Update();
     gPad->SetRightMargin(0.15);
@@ -613,7 +607,6 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     jetkinematiccheck_jetmassvseta_pfx->SetYTitle("Jet #eta");
     jetkinematiccheck_jetmassvseta_pfx->SetZTitle("Counts");
     jetkinematiccheck_jetmassvseta_pfx->DrawCopy("SAME");  // Profile
-    gStyle->SetPalette(4, kBird);
     gPad->UseCurrentStyle();
     gPad->Update();
     gPad->SetRightMargin(0.15);
@@ -637,7 +630,6 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     jetkinematiccheck_jetmassvspt_pfx->SetYTitle("Jet p_{T} [GeV/c]");
     jetkinematiccheck_jetmassvspt_pfx->SetZTitle("Counts");
     jetkinematiccheck_jetmassvspt_pfx->DrawCopy("SAME");  // Profile
-    gStyle->SetPalette(4, kBird);
     gPad->UseCurrentStyle();
     gPad->Update();
     gPad->SetRightMargin(0.15);

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -44,7 +44,7 @@ class JetDraw : public QADraw
   void SetJetSummary(TCanvas* c);
 
  private:
-  int MakeCanvas(const std::string &name, const int nHist, TCanvas* canvas, TPad* run, VPad1D& pads);
+  int MakeCanvas(const std::string &name, const int nHist, VCanvas1D& canvas, VPad1D& run);
   int DrawRho(uint32_t trigger);
   int DrawConstituents(uint32_t trigToDraw, JetRes resToDraw);
   int DrawJetKinematics(uint32_t trigger, JetRes reso);

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -41,6 +41,7 @@ class JetDraw : public QADraw
   int Draw(const std::string &what = "ALL") override;
   int DBVarInit();
   void SetJetSummary(TCanvas* c);
+  void SetDoDebug(const bool debug);
 
  private:
   int MakeCanvas(const std::string &name, const int nHist, VCanvas1D& canvas, VPad1D& run);
@@ -63,6 +64,9 @@ class JetDraw : public QADraw
   VPad2D m_vecCstRun;
   VPad2D m_vecKineRun;
   VPad2D m_vecSeedRun;
+
+  // turn debugging statements on/off
+  bool m_do_debug;
 
   const char* m_constituent_prefix;
   const char* m_rho_prefix;

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -19,7 +19,6 @@ class TH2;
 // aliases for convenience
 using VPad1D    = std::vector<TPad*>;
 using VPad2D    = std::vector<std::vector<TPad*>>;
-using VPad3D    = std::vector<std::vector<std::vector<TPad*>>>;
 using VCanvas1D = std::vector<TCanvas*>;
 using VCanvas2D = std::vector<std::vector<TCanvas*>>;
 
@@ -64,12 +63,6 @@ class JetDraw : public QADraw
   VPad2D m_vecCstRun;
   VPad2D m_vecKineRun;
   VPad2D m_vecSeedRun;
-
-  // for individual pads on each canvas
-  VPad2D m_vecRhoPad;
-  VPad3D m_vecCstPad;
-  VPad3D m_vecKinePad;
-  VPad3D m_vecSeedPad;
 
   const char* m_constituent_prefix;
   const char* m_rho_prefix;

--- a/subsystems/jets/macros/draw_jet.C
+++ b/subsystems/jets/macros/draw_jet.C
@@ -20,8 +20,11 @@ void draw_jet(const std::string& rootfile, const bool do_debug = false) {
               << std::endl;
   }
 
-  // create instances of relevant clients/modules
-  JetDraw*      jets   = new JetDraw();
+  // create instance of relevant module
+  JetDraw* jets = new JetDraw();
+  jets -> SetDoDebug(do_debug);
+
+  // create draw client
   QADrawClient* client = QADrawClient::instance();
   client -> registerDrawer(jets);
   if (do_debug) {
@@ -39,7 +42,6 @@ void draw_jet(const std::string& rootfile, const bool do_debug = false) {
   if (do_debug) {
     std::cout << " --- HTML page made" << std::endl;
   }
-
 
   // delete QADrawClient instance
   delete client;


### PR DESCRIPTION
This PR resolves a major bug introduced when switching over to vectors to manage canvases rather than c arrays: the old way of adding `TCanvas`s and `TPad`s to the vectors that tracked them resulted in several dangling pointers. Alongside this, this PR makes a few small fixes listed below.

Full list of changes:
- Uses `emplace_back()` rather than `push_back()` where needed;
- Removes now redundant vectors tracking pointers to individual pads;
- Adds an option to adjust verbosity;
- Draw options now throw error if they try to process an unknown resolution parameter;
- And redundant calls to `TStyle::SetColorPalette` were removed.