### PR TITLE
Add jet debugging tools

### DIFF
--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -5,6 +5,7 @@
 #include <qahtml/QADrawDB.h>
 #include <TCanvas.h>
 #include <TDatime.h>
+#include <TFile.h>
 #include <TGraphErrors.h>
 #include <TH1.h>
 #include <TH2.h>
@@ -918,3 +919,132 @@ void JetDraw::myText(double x, double y, int color, const char *text, double tsi
   l.SetTextColor(color);
   l.DrawLatex(x, y, text);
 }
+
+
+// ----------------------------------------------------------------------------
+//! Save canvases to file
+// ----------------------------------------------------------------------------
+/*! Helper method to save all canvases to
+ *  a specified file. This is useful for
+ *  debugging and quick testing when
+ *  adjusting plotting details/etc.
+ */
+void JetDraw::SaveCanvasesToFile(TFile* file)
+{
+
+  // emit debugging message
+  if (m_do_debug)
+  {
+
+    std::cout << "Saving plots to file:\n"
+              << "  " << file -> GetName()
+              << std::endl;
+  }
+
+  // check if you can cd into file
+  //   - if not, exit
+  const bool isGoodCD = file -> cd();
+  if (!isGoodCD)
+  {
+    if (m_do_debug)
+    {
+      std::cerr << PHWHERE << "WARNING: couldn't cd into output file!" << std::endl;
+    }
+    return;
+  }
+
+  // for tracking how many plots were saved
+  std::size_t nWrite = 0;
+
+  // save rho canvases
+  for (auto rho : m_vecRhoCanvas) {
+
+
+    rho -> Write();
+    ++nWrite;
+
+/* TO REMOVE
+    std::cout << "  RHO TEST " << rho << std::endl;
+
+    // grab name
+    std::string sname( rho -> GetName() );
+    sname += ".root";
+    std::cout << "Saving " << sname << "..." << std::endl;
+
+    rho -> Draw();
+
+    // actually save histogram
+    rho -> SaveAs( sname.data() );
+*/
+
+  }
+  if (m_do_debug) std::cout << "  -- Saved rho plots." << std::endl;
+
+  // save constituent canvases
+  for (auto cstRow : m_vecCstCanvas) {
+    for (auto cst : cstRow) {
+
+      cst -> Write();
+      ++nWrite;
+
+/* TO REMOVE
+      // grab name
+      std::string sname( cst -> GetName() );
+      sname += ".root";
+
+      // actually save histogram
+      cst -> SaveAs( sname.data() );
+      std::cout << "Saving " << cst -> GetName() << "..." << std::endl;
+*/
+    }
+  }
+  if (m_do_debug) std::cout << "  -- Saved constituent plots." << std::endl;
+
+  // save kinematics canvases
+  for (auto kinRow : m_vecKineCanvas) {
+    for (auto kin : kinRow) {
+
+      kin -> Write();
+      ++nWrite;
+
+/* TO REMOVE
+      // grab name
+      std::string sname( kin -> GetName() );
+      sname += ".root";
+
+      // actually save histogram
+      kin -> SaveAs( sname.data() );
+      std::cout << "Saving " << kin -> GetName() << "..." << std::endl;
+*/
+    }
+  }
+  if (m_do_debug) std::cout << "  -- Saved kinematic plots." << std::endl;
+
+  // save seed canvases
+  for (auto sedRow : m_vecSeedCanvas) {
+    for (auto sed : sedRow) {
+
+      sed -> Write();
+      ++nWrite;
+
+/* TO REMOVE
+      // grab name
+      std::string sname( sed -> GetName() );
+      sname += ".root";
+
+      // actually save histogram
+      sed -> SaveAs( sname.data() );
+      std::cout << "Saving " << sed -> GetName() << "..." << std::endl;
+*/
+    }
+  }
+  if (m_do_debug) std::cout << "  -- Saved seed plots." << std::endl;
+
+  // announce how many plots saved & exit
+  if (m_do_debug)
+  {
+    std::cout << "Finished saving plots: " << nWrite << " plots written." << std::endl;
+  }
+  return;
+
+}  // end 'SaveCanvasesToFile(TFile*)'

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -945,7 +945,8 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
   std::size_t nWrite = 0;
 
   // save rho canvases
-  for (auto rho : m_vecRhoCanvas) {
+  for (auto rho : m_vecRhoCanvas)
+  {
     rho -> Draw();
     rho -> Write();
     ++nWrite;
@@ -953,8 +954,10 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
   if (m_do_debug) std::cout << "  -- Saved rho plots." << std::endl;
 
   // save constituent canvases
-  for (auto cstRow : m_vecCstCanvas) {
-    for (auto cst : cstRow) {
+  for (auto cstRow : m_vecCstCanvas)
+  {
+    for (auto cst : cstRow)
+    {
       cst -> Draw();
       cst -> Write();
       ++nWrite;
@@ -963,8 +966,10 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
   if (m_do_debug) std::cout << "  -- Saved constituent plots." << std::endl;
 
   // save kinematics canvases
-  for (auto kinRow : m_vecKineCanvas) {
-    for (auto kin : kinRow) {
+  for (auto kinRow : m_vecKineCanvas)
+  {
+    for (auto kin : kinRow)
+    {
       kin -> Draw();
       kin -> Write();
       ++nWrite;
@@ -973,8 +978,10 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
   if (m_do_debug) std::cout << "  -- Saved kinematic plots." << std::endl;
 
   // save seed canvases
-  for (auto sedRow : m_vecSeedCanvas) {
-    for (auto sed : sedRow) {
+  for (auto sedRow : m_vecSeedCanvas)
+  {
+    for (auto sed : sedRow)
+    {
       sed -> Draw();
       sed -> Write();
       ++nWrite;

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -924,7 +924,6 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
   // emit debugging message
   if (m_do_debug)
   {
-
     std::cout << "Saving plots to file:\n"
               << "  " << file -> GetName()
               << std::endl;

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -910,17 +910,6 @@ void JetDraw::SetDoDebug(const bool debug)
   m_do_debug = debug;
 }
 
-void JetDraw::myText(double x, double y, int color, const char *text, double tsize)
-{
-  TLatex l;
-  l.SetTextAlign(22);
-  l.SetTextSize(tsize);
-  l.SetNDC();
-  l.SetTextColor(color);
-  l.DrawLatex(x, y, text);
-}
-
-
 // ----------------------------------------------------------------------------
 //! Save canvases to file
 // ----------------------------------------------------------------------------
@@ -958,44 +947,18 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
 
   // save rho canvases
   for (auto rho : m_vecRhoCanvas) {
-
-
+    rho -> Draw();
     rho -> Write();
     ++nWrite;
-
-/* TO REMOVE
-    std::cout << "  RHO TEST " << rho << std::endl;
-
-    // grab name
-    std::string sname( rho -> GetName() );
-    sname += ".root";
-    std::cout << "Saving " << sname << "..." << std::endl;
-
-    rho -> Draw();
-
-    // actually save histogram
-    rho -> SaveAs( sname.data() );
-*/
-
   }
   if (m_do_debug) std::cout << "  -- Saved rho plots." << std::endl;
 
   // save constituent canvases
   for (auto cstRow : m_vecCstCanvas) {
     for (auto cst : cstRow) {
-
+      cst -> Draw();
       cst -> Write();
       ++nWrite;
-
-/* TO REMOVE
-      // grab name
-      std::string sname( cst -> GetName() );
-      sname += ".root";
-
-      // actually save histogram
-      cst -> SaveAs( sname.data() );
-      std::cout << "Saving " << cst -> GetName() << "..." << std::endl;
-*/
     }
   }
   if (m_do_debug) std::cout << "  -- Saved constituent plots." << std::endl;
@@ -1003,19 +966,9 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
   // save kinematics canvases
   for (auto kinRow : m_vecKineCanvas) {
     for (auto kin : kinRow) {
-
+      kin -> Draw();
       kin -> Write();
       ++nWrite;
-
-/* TO REMOVE
-      // grab name
-      std::string sname( kin -> GetName() );
-      sname += ".root";
-
-      // actually save histogram
-      kin -> SaveAs( sname.data() );
-      std::cout << "Saving " << kin -> GetName() << "..." << std::endl;
-*/
     }
   }
   if (m_do_debug) std::cout << "  -- Saved kinematic plots." << std::endl;
@@ -1023,19 +976,9 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
   // save seed canvases
   for (auto sedRow : m_vecSeedCanvas) {
     for (auto sed : sedRow) {
-
+      sed -> Draw();
       sed -> Write();
       ++nWrite;
-
-/* TO REMOVE
-      // grab name
-      std::string sname( sed -> GetName() );
-      sname += ".root";
-
-      // actually save histogram
-      sed -> SaveAs( sname.data() );
-      std::cout << "Saving " << sed -> GetName() << "..." << std::endl;
-*/
     }
   }
   if (m_do_debug) std::cout << "  -- Saved seed plots." << std::endl;
@@ -1048,3 +991,13 @@ void JetDraw::SaveCanvasesToFile(TFile* file)
   return;
 
 }  // end 'SaveCanvasesToFile(TFile*)'
+
+void JetDraw::myText(double x, double y, int color, const char *text, double tsize)
+{
+  TLatex l;
+  l.SetTextAlign(22);
+  l.SetTextSize(tsize);
+  l.SetNDC();
+  l.SetTextColor(color);
+  l.DrawLatex(x, y, text);
+}

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -11,10 +11,11 @@
 class QADB;
 class QADBVar;
 class TCanvas;
+class TFile;
 class TGraphErrors;
-class TPad;
 class TH1;
 class TH2;
+class TPad;
 
 // aliases for convenience
 using VPad1D    = std::vector<TPad*>;
@@ -50,6 +51,7 @@ class JetDraw : public QADraw
   int DrawJetKinematics(uint32_t trigger, JetRes reso);
   int DrawJetSeed(uint32_t trigger, JetRes reso);
   void myText(double x, double y, int color, const char *text, double tsize = 0.04);
+  void SaveCanvasesToFile(TFile* file);
 
   TCanvas* jetSummary = nullptr;
 

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -43,6 +43,7 @@ class JetDraw : public QADraw
   int DBVarInit();
   void SetJetSummary(TCanvas* c);
   void SetDoDebug(const bool debug);
+  void SaveCanvasesToFile(TFile* file);
 
  private:
   int MakeCanvas(const std::string &name, const int nHist, VCanvas1D& canvas, VPad1D& run);
@@ -51,7 +52,6 @@ class JetDraw : public QADraw
   int DrawJetKinematics(uint32_t trigger, JetRes reso);
   int DrawJetSeed(uint32_t trigger, JetRes reso);
   void myText(double x, double y, int color, const char *text, double tsize = 0.04);
-  void SaveCanvasesToFile(TFile* file);
 
   TCanvas* jetSummary = nullptr;
 

--- a/subsystems/jets/macros/draw_jet.C
+++ b/subsystems/jets/macros/draw_jet.C
@@ -2,19 +2,35 @@
 #include <iostream>
 #include <qahtml/jet/JetDraw.h>
 #include <sPhenixStyle.C>
+#include <TFile.h>
 #include <TSystem.h>
 
 R__LOAD_LIBRARY(libqadrawjet.so)
 
 
+
 // ----------------------------------------------------------------------------
 //! Draw jet QA
 // ----------------------------------------------------------------------------
-void draw_jet(const std::string& rootfile, const bool do_debug = false) {
+/*! Short ROOT macro to test the Jet QADrawClient.
+ *  Reads histograms in `infile` and saves produced
+ *  plots to `outfile`.
+ *
+ *  \param[in]  infile   input histogram ROOT file
+ *  \param[out] outfile  output ROOT file to save plots to
+ *  \param      do_debug turn on (true)/ off (false) debugging messages
+ *  \param      do_html  turn on (true)/ off (false) trying to make html page
+ */
+void draw_jet(const std::string& infile,
+              const std::string& outfile,
+              const bool do_debug = false,
+              const bool do_html = false)
+{
 
   // set plotting style to sPHENIX
   SetsPhenixStyle();
-  if (do_debug) {
+  if (do_debug)
+  {
     std::cout << " --- Testing JetDraw\n"
               << " --- Style set to sPHENIX"
               << std::endl;
@@ -27,25 +43,42 @@ void draw_jet(const std::string& rootfile, const bool do_debug = false) {
   // create draw client
   QADrawClient* client = QADrawClient::instance();
   client -> registerDrawer(jets);
-  if (do_debug) {
+  if (do_debug)
+  {
     std::cout << " --- JetDraw client registered" << std::endl;
   }
 
   // read histograms from file
-  client -> ReadHistogramsFromFile(rootfile);
-  if (do_debug) {
+  client -> ReadHistogramsFromFile(infile);
+  if (do_debug)
+  {
     std::cout << " --- Histograms read" << std::endl;
   }
 
-  // make html page
-  client -> MakeHtml();
-  if (do_debug) {
-    std::cout << " --- HTML page made" << std::endl;
+  // make html page if needed
+  if (do_html)
+  {
+    client -> MakeHtml("ALL");
+    if (do_debug) std::cout << " --- HTML page made" << std::endl;
+  }
+  else
+  {
+    jets -> Draw("ALL");
+    if (do_debug) std::cout << " --- Drew plots" << std::endl;
+  }
+
+  // save histograms
+  TFile* output = new TFile(outfile.data(), "recreate");
+  jets -> SaveCanvasesToFile(output);
+  if (do_debug)
+  {
+     std::cout << " --- Save plots to file" << std::endl;
   }
 
   // delete QADrawClient instance
   delete client;
-  if (do_debug) {
+  if (do_debug)
+  {
     std::cout << " --- Deleted QADrawClient, exiting" << std::endl;
   }
 


### PR DESCRIPTION
This PR adds a method to save all produced plots to a specified ROOT file and updates the `draw_jet.C` macro accordingly. This functionality was found to be useful in the initial debugging of `JetDraw`, and is very useful for quick turnaround when testing changes to the plotting details.