### PR TITLE
Fix micromegas histogram

### DIFF
--- a/subsystems/micromegas/MicromegasDraw.cc
+++ b/subsystems/micromegas/MicromegasDraw.cc
@@ -31,16 +31,7 @@
 MicromegasDraw::MicromegasDraw(const std::string &name)
   : QADraw(name)
 {
-  memset(TC, 0, sizeof(TC));
-  memset(transparent, 0, sizeof(transparent));
-  memset(Pad, 0, sizeof(Pad));
   DBVarInit();
-  return;
-}
-
-MicromegasDraw::~MicromegasDraw()
-{
-  /* delete db; */
   return;
 }
 
@@ -67,10 +58,10 @@ int MicromegasDraw::Draw(const std::string &what)
   return iret;
 }
 
-TH1F* MicromegasDraw::ClusterAverage(TH2F* hist, std::string type) 
+TH1F* MicromegasDraw::ClusterAverage(TH2F* hist, std::string type)
 {
-  int nX = hist->GetNbinsX();  
-  int nY = hist->GetNbinsY(); 
+  int nX = hist->GetNbinsX();
+  int nY = hist->GetNbinsY();
 
   TH1F* graph = new TH1F( Form("avg_%s", type.c_str()), "", nX, hist->GetXaxis()->GetXmin(), hist->GetXaxis()->GetXmax());
 
@@ -78,44 +69,27 @@ TH1F* MicromegasDraw::ClusterAverage(TH2F* hist, std::string type)
 
   for (int i = 1; i <= nX; ++i)
     {
-      double sum_y = 0; 
-      double totalEntries = 0;  
-      for (int j = 1; j <= nY; ++j) 
+      double sum_y = 0;
+      double totalEntries = 0;
+      for (int j = 1; j <= nY; ++j)
 	{
-	  double value = hist->GetBinContent(i, j); 
-	  double center = hist->GetYaxis()->GetBinCenter(j);  
+	  double value = hist->GetBinContent(i, j);
+	  double center = hist->GetYaxis()->GetBinCenter(j);
 	  sum_y += value * center;
-	  totalEntries += value;   
+	  totalEntries += value;
 	}
 
       double average;
       if (totalEntries > 0){average = sum_y / totalEntries;} else{average = 0;}
       graph->SetBinContent(i, average);
       const char* label = hist->GetXaxis()->GetBinLabel(i);
-      graph->GetXaxis()->SetBinLabel(i, label); 
+      graph->GetXaxis()->SetBinLabel(i, label);
     }
 
   graph->SetMarkerStyle(8);
 
   return graph;
 }
-
-int MicromegasDraw::BinValues(TH1F* hist)
-{
-    if (!hist) return 0;
-    for (int i = 1; i <= hist->GetNbinsX(); ++i)  
-    {
-      double x = hist->GetXaxis()->GetBinCenter(i);
-      double y = hist->GetBinContent(i) + 0.03 * hist->GetMaximum();
-      TLatex* latex = new TLatex();
-      latex->SetTextSize(0.05); 
-      latex->SetTextAlign(22);
-      latex->DrawLatex(x, y, Form("%.5f", hist->GetBinContent(i)));
-      delete latex;
-      }
-    return 0;
-}
-
 
 int MicromegasDraw::MakeCanvas(const std::string &name, int num)
 {
@@ -130,20 +104,20 @@ int MicromegasDraw::MakeCanvas(const std::string &name, int num)
   Pad[num][1] = new TPad((boost::format("mypad%d1") % num).str().c_str(), "a", 0.5, 0.52, 0.95, 0.97, 0);
   Pad[num][2] = new TPad((boost::format("mypad%d2") % num).str().c_str(), "name", 0.05, 0.02, 0.45, 0.47, 0);
   Pad[num][3] = new TPad((boost::format("mypad%d3") % num).str().c_str(), "here", 0.5, 0.02, 0.95, 0.47, 0);
- 
+
   for (int i=0; i<4; i++)
     {
-      Pad[num][i]->SetTopMargin(0.15); 
+      Pad[num][i]->SetTopMargin(0.15);
       Pad[num][i]->SetBottomMargin(0.15);
       Pad[num][i]->SetRightMargin(0.15);
       Pad[num][i]->SetLeftMargin(0.15);
     }
-   
+
   Pad[num][0]->Draw();
   Pad[num][1]->Draw();
   Pad[num][2]->Draw();
   Pad[num][3]->Draw();
-  
+
   // this one is used to plot the run number on the canvas
   transparent[num] = new TPad((boost::format("transparent%d") % num).str().c_str(), "this does not show", 0, 0, 1, 1);
   transparent[num]->SetFillStyle(4000);
@@ -206,7 +180,7 @@ int MicromegasDraw::DrawClusterInfo()
   h_cluster_charge->SetMinimum(0);
   h_cluster_charge->SetMaximum(1000);
   h_cluster_charge->DrawCopy("P");
-  
+
   Pad[0][3]->cd();
   efficiency->SetMinimum(0);
   efficiency->SetMaximum(1);
@@ -235,7 +209,7 @@ int MicromegasDraw::DrawBCOInfo()
     }
 
   TH1F *h_drop= new TH1F("h_drop", "Drop Rate", 3, 0, 3);
-  
+
   h_drop->GetXaxis()->SetBinLabel(1, "5001");
   h_drop->GetXaxis()->SetBinLabel(2, "5002");
   h_drop->GetXaxis()->SetBinLabel(3, "all");
@@ -244,8 +218,8 @@ int MicromegasDraw::DrawBCOInfo()
   h_drop->SetTitle("Fraction of Dropped Waveforms by packet");
 
   h_drop->SetBinContent(1, ( h_waveform_bco_dropped->GetBinContent(1)+ h_waveform_pool_dropped->GetBinContent(1))/h_waveform_total->GetBinContent(1));
-  h_drop->SetBinContent(2, ( h_waveform_bco_dropped->GetBinContent(2)+ h_waveform_pool_dropped->GetBinContent(2))/h_waveform_total->GetBinContent(2)); 
-  h_drop->SetBinContent(3, ( h_waveform_bco_dropped->GetBinContent(1)+ h_waveform_pool_dropped->GetBinContent(1)+h_waveform_bco_dropped->GetBinContent(2)+ h_waveform_pool_dropped->GetBinContent(2))/(h_waveform_total->GetBinContent(1)+h_waveform_total->GetBinContent(2)) ); 
+  h_drop->SetBinContent(2, ( h_waveform_bco_dropped->GetBinContent(2)+ h_waveform_pool_dropped->GetBinContent(2))/h_waveform_total->GetBinContent(2));
+  h_drop->SetBinContent(3, ( h_waveform_bco_dropped->GetBinContent(1)+ h_waveform_pool_dropped->GetBinContent(1)+h_waveform_bco_dropped->GetBinContent(2)+ h_waveform_pool_dropped->GetBinContent(2))/(h_waveform_total->GetBinContent(1)+h_waveform_total->GetBinContent(2)) );
 
   TH1F *h_gl1= new TH1F("h_gl1", "Match Rate", 3, 0, 3);
   h_gl1->GetXaxis()->SetBinLabel(1, "5001");
@@ -255,7 +229,7 @@ int MicromegasDraw::DrawBCOInfo()
   h_gl1->SetBinContent(3,h_gl1_raw->GetBinContent(4)/h_gl1_raw->GetBinContent(1));
   h_gl1->SetBinContent(2,h_gl1_raw->GetBinContent(3)/h_gl1_raw->GetBinContent(1));
   h_gl1->SetBinContent(1,h_gl1_raw->GetBinContent(2)/h_gl1_raw->GetBinContent(1));
-  
+
   if (!TC[1])
   {
     MakeCanvas("BCO_QA", 1);
@@ -267,7 +241,7 @@ int MicromegasDraw::DrawBCOInfo()
   Pad[1][0]->cd();
   h_drop->SetMinimum(0);
   h_drop->SetMaximum(1.6);
-  h_drop->SetFillColor(42); 
+  h_drop->SetFillColor(42);
   h_drop->SetFillStyle(3002);
   h_drop->DrawCopy();
 
@@ -277,18 +251,18 @@ int MicromegasDraw::DrawBCOInfo()
   legend_drop->SetBorderSize(0);
   legend_drop->SetFillStyle(0);
 
-  for (int i = 1; i <= h_drop->GetNbinsX(); ++i)  
+  for (int i = 1; i <= h_drop->GetNbinsX(); ++i)
   {
     legend_drop->AddEntry((TObject*)0, Form("%s: %.4f", h_drop->GetXaxis()->GetBinLabel(i), h_drop->GetBinContent(i)), "");
   }
   legend_drop->Draw();
-  gPad->Update(); 
+  gPad->Update();
 
   Pad[1][1]->cd();
   h_gl1->GetXaxis()->SetTitle("Packet");
   h_gl1->GetYaxis()->SetTitle("Match Rate");
   h_gl1->SetTitle("Matching Tagger Rate by packet");
-  h_gl1->SetFillColor(42); 
+  h_gl1->SetFillColor(42);
   h_gl1->SetFillStyle(3002);
   h_gl1->SetMinimum(0);
   h_gl1->SetMaximum(1.6);
@@ -300,12 +274,12 @@ int MicromegasDraw::DrawBCOInfo()
   legend_gl1->SetBorderSize(0);
   legend_gl1->SetFillStyle(0);
 
-  for (int i = 1; i <= h_gl1->GetNbinsX(); ++i)  
+  for (int i = 1; i <= h_gl1->GetNbinsX(); ++i)
   {
     legend_gl1->AddEntry((TObject*)0, Form("%s: %.4f", h_gl1->GetXaxis()->GetBinLabel(i), h_gl1->GetBinContent(i)), "");
   }
   legend_gl1->Draw();
-  gPad->Update(); 
+  gPad->Update();
 
   TC[1]->Update();
 
@@ -324,7 +298,7 @@ int MicromegasDraw::MakeHtml(const std::string &what)
   std::string pngfile;
 
   // Register the canvas png file to the menu and produces the png file.
-  
+
   if (what == "ALL" || what == "CLUSTERS")
     {
       pngfile = cl->htmlRegisterPage(*this, "cluster_info", "1", "png");

--- a/subsystems/micromegas/MicromegasDraw.cc
+++ b/subsystems/micromegas/MicromegasDraw.cc
@@ -58,12 +58,12 @@ int MicromegasDraw::Draw(const std::string &what)
   return iret;
 }
 
-TH1F* MicromegasDraw::ClusterAverage(TH2F* hist, std::string type)
+TH1* MicromegasDraw::ClusterAverage(TH2* hist, std::string type)
 {
   int nX = hist->GetNbinsX();
   int nY = hist->GetNbinsY();
 
-  TH1F* graph = new TH1F( Form("avg_%s", type.c_str()), "", nX, hist->GetXaxis()->GetXmin(), hist->GetXaxis()->GetXmax());
+  auto graph = new TH1F( Form("avg_%s", type.c_str()), "", nX, hist->GetXaxis()->GetXmin(), hist->GetXaxis()->GetXmax());
 
   std::vector<double> xValues, yAverages;
 
@@ -130,11 +130,11 @@ int MicromegasDraw::DrawClusterInfo()
 {
   QADrawClient *cl = QADrawClient::instance();
 
-  TH1F* h_cluster_count_ref = dynamic_cast<TH1F*>(cl->getHisto("h_MicromegasClusterQA_clustercount_ref"));
-  TH1F* h_cluster_count_found = dynamic_cast<TH1F*>(cl->getHisto("h_MicromegasClusterQA_clustercount_found"));
-  TH2F* h_cluster_multiplicity_raw = dynamic_cast<TH2F*>(cl->getHisto("h_MicromegasClusterQA_cluster_multiplicity"));
-  TH2F* h_cluster_size_raw = dynamic_cast<TH2F*>(cl->getHisto("h_MicromegasClusterQA_cluster_size"));
-  TH2F* h_cluster_charge_raw = dynamic_cast<TH2F*>(cl->getHisto("h_MicromegasClusterQA_cluster_charge"));
+  auto h_cluster_count_ref = static_cast<TH1*>(cl->getHisto("h_MicromegasClusterQA_clustercount_ref"));
+  auto h_cluster_count_found = static_cast<TH1*>(cl->getHisto("h_MicromegasClusterQA_clustercount_found"));
+  auto h_cluster_multiplicity_raw = static_cast<TH2*>(cl->getHisto("h_MicromegasClusterQA_cluster_multiplicity"));
+  auto h_cluster_size_raw = static_cast<TH2*>(cl->getHisto("h_MicromegasClusterQA_cluster_size"));
+  auto h_cluster_charge_raw = static_cast<TH2*>(cl->getHisto("h_MicromegasClusterQA_cluster_charge"));
 
   if (!h_cluster_count_ref || !h_cluster_count_found || !h_cluster_multiplicity_raw || !h_cluster_size_raw || !h_cluster_charge_raw)
   {
@@ -142,12 +142,12 @@ int MicromegasDraw::DrawClusterInfo()
     return -1;
   }
 
-  TH1F *efficiency = (TH1F*)h_cluster_count_found->Clone("efficiency");
+  auto efficiency = static_cast<TH1*>(h_cluster_count_found->Clone("efficiency"));
   efficiency->Divide(h_cluster_count_ref);
 
-  TH1F* h_cluster_multiplicity = ClusterAverage(h_cluster_multiplicity_raw, "mult");
-  TH1F* h_cluster_size = ClusterAverage(h_cluster_size_raw, "size");
-  TH1F* h_cluster_charge = ClusterAverage(h_cluster_charge_raw, "charge");
+  auto h_cluster_multiplicity = ClusterAverage(h_cluster_multiplicity_raw, "mult");
+  auto h_cluster_size = ClusterAverage(h_cluster_size_raw, "size");
+  auto h_cluster_charge = ClusterAverage(h_cluster_charge_raw, "charge");
 
   if (!TC[0])
   {
@@ -197,10 +197,10 @@ int MicromegasDraw::DrawClusterInfo()
 int MicromegasDraw::DrawBCOInfo()
 {
   QADrawClient *cl = QADrawClient::instance();
-  TH1F* h_waveform_bco_dropped = dynamic_cast<TH1F*>(cl->getHisto("h_MicromegasBCOQA_waveform_count_dropped_bco"));
-  TH1F* h_waveform_pool_dropped = dynamic_cast<TH1F*>(cl->getHisto("h_MicromegasBCOQA_waveform_count_dropped_pool"));
-  TH1F* h_waveform_total = dynamic_cast<TH1F*>(cl->getHisto("h_MicromegasBCOQA_waveform_count_total"));
-  TH1F* h_gl1_raw = dynamic_cast<TH1F*>(cl->getHisto("h_MicromegasBCOQA_packet_stat"));
+  auto h_waveform_bco_dropped = static_cast<TH1*>(cl->getHisto("h_MicromegasBCOQA_waveform_count_dropped_bco"));
+  auto h_waveform_pool_dropped = static_cast<TH1*>(cl->getHisto("h_MicromegasBCOQA_waveform_count_dropped_pool"));
+  auto h_waveform_total = static_cast<TH1*>(cl->getHisto("h_MicromegasBCOQA_waveform_count_total"));
+  auto h_gl1_raw = static_cast<TH1*>(cl->getHisto("h_MicromegasBCOQA_packet_stat"));
 
   if (!h_waveform_bco_dropped || !h_waveform_pool_dropped || !h_waveform_total || !h_gl1_raw)
     {
@@ -208,8 +208,7 @@ int MicromegasDraw::DrawBCOInfo()
       return -1;
     }
 
-  TH1F *h_drop= new TH1F("h_drop", "Drop Rate", 3, 0, 3);
-
+  auto h_drop= new TH1F("h_drop", "Drop Rate", 3, 0, 3);
   h_drop->GetXaxis()->SetBinLabel(1, "5001");
   h_drop->GetXaxis()->SetBinLabel(2, "5002");
   h_drop->GetXaxis()->SetBinLabel(3, "all");
@@ -217,18 +216,18 @@ int MicromegasDraw::DrawBCOInfo()
   h_drop->GetYaxis()->SetTitle("Waveform Drop Rate");
   h_drop->SetTitle("Fraction of Dropped Waveforms by packet");
 
-  h_drop->SetBinContent(1, ( h_waveform_bco_dropped->GetBinContent(1)+ h_waveform_pool_dropped->GetBinContent(1))/h_waveform_total->GetBinContent(1));
-  h_drop->SetBinContent(2, ( h_waveform_bco_dropped->GetBinContent(2)+ h_waveform_pool_dropped->GetBinContent(2))/h_waveform_total->GetBinContent(2));
-  h_drop->SetBinContent(3, ( h_waveform_bco_dropped->GetBinContent(1)+ h_waveform_pool_dropped->GetBinContent(1)+h_waveform_bco_dropped->GetBinContent(2)+ h_waveform_pool_dropped->GetBinContent(2))/(h_waveform_total->GetBinContent(1)+h_waveform_total->GetBinContent(2)) );
+  h_drop->SetBinContent(1, double(h_waveform_bco_dropped->GetBinContent(1)+ h_waveform_pool_dropped->GetBinContent(1))/h_waveform_total->GetBinContent(1));
+  h_drop->SetBinContent(2, double(h_waveform_bco_dropped->GetBinContent(2)+ h_waveform_pool_dropped->GetBinContent(2))/h_waveform_total->GetBinContent(2));
+  h_drop->SetBinContent(3, double(h_waveform_bco_dropped->GetBinContent(1)+ h_waveform_pool_dropped->GetBinContent(1)+h_waveform_bco_dropped->GetBinContent(2)+ h_waveform_pool_dropped->GetBinContent(2))/(h_waveform_total->GetBinContent(1)+h_waveform_total->GetBinContent(2)) );
 
-  TH1F *h_gl1= new TH1F("h_gl1", "Match Rate", 3, 0, 3);
+  auto h_gl1= new TH1F("h_gl1", "Match Rate", 3, 0, 3);
   h_gl1->GetXaxis()->SetBinLabel(1, "5001");
   h_gl1->GetXaxis()->SetBinLabel(2, "5002");
   h_gl1->GetXaxis()->SetBinLabel(3, "all");
 
-  h_gl1->SetBinContent(3,h_gl1_raw->GetBinContent(4)/h_gl1_raw->GetBinContent(1));
-  h_gl1->SetBinContent(2,h_gl1_raw->GetBinContent(3)/h_gl1_raw->GetBinContent(1));
-  h_gl1->SetBinContent(1,h_gl1_raw->GetBinContent(2)/h_gl1_raw->GetBinContent(1));
+  h_gl1->SetBinContent(3,double(h_gl1_raw->GetBinContent(4))/h_gl1_raw->GetBinContent(1));
+  h_gl1->SetBinContent(2,double(h_gl1_raw->GetBinContent(3))/h_gl1_raw->GetBinContent(1));
+  h_gl1->SetBinContent(1,double(h_gl1_raw->GetBinContent(2))/h_gl1_raw->GetBinContent(1));
 
   if (!TC[1])
   {
@@ -268,7 +267,7 @@ int MicromegasDraw::DrawBCOInfo()
   h_gl1->SetMaximum(1.6);
   h_gl1->DrawCopy();
 
-  TLegend* legend_gl1 = new TLegend(0.65, 0.6, 0.85, 0.84);
+  auto legend_gl1 = new TLegend(0.65, 0.6, 0.85, 0.84);
   legend_gl1->SetHeader("Values", "C");
   legend_gl1->SetTextSize(0.045);
   legend_gl1->SetBorderSize(0);
@@ -294,7 +293,7 @@ int MicromegasDraw::MakeHtml(const std::string &what)
     return iret;
   }
 
-  QADrawClient *cl = QADrawClient::instance();
+  auto cl = QADrawClient::instance();
   std::string pngfile;
 
   // Register the canvas png file to the menu and produces the png file.

--- a/subsystems/micromegas/MicromegasDraw.h
+++ b/subsystems/micromegas/MicromegasDraw.h
@@ -3,17 +3,10 @@
 
 #include <qahtml/QADraw.h>
 
-#include <vector>
-
-class QADB;
-class QADBVar;
 class TCanvas;
-class TGraphErrors;
 class TPad;
-class TH1F;
-class TH2F;
-class TGraph;
-class TLegend;
+class TH1;
+class TH2;
 
 class MicromegasDraw : public QADraw
 {
@@ -26,7 +19,7 @@ class MicromegasDraw : public QADraw
 
  private:
   int MakeCanvas(const std::string &name, int num);
-  TH1F* ClusterAverage(TH2F*, std::string);
+  TH1* ClusterAverage(TH2*, std::string);
   int DrawClusterInfo();
   int DrawBCOInfo();
   TCanvas *TC[4]{};

--- a/subsystems/micromegas/MicromegasDraw.h
+++ b/subsystems/micromegas/MicromegasDraw.h
@@ -17,9 +17,8 @@ class TLegend;
 
 class MicromegasDraw : public QADraw
 {
- public: 
+ public:
   MicromegasDraw(const std::string &name = "MicromegasQA");
-  ~MicromegasDraw() override;
 
   int Draw(const std::string &what = "ALL") override;
   int MakeHtml(const std::string &what = "ALL") override;
@@ -28,8 +27,6 @@ class MicromegasDraw : public QADraw
  private:
   int MakeCanvas(const std::string &name, int num);
   TH1F* ClusterAverage(TH2F*, std::string);
-  int BinValues(TH1F*);
-  int DrawTileInfo();
   int DrawClusterInfo();
   int DrawBCOInfo();
   TCanvas *TC[4]{};


### PR DESCRIPTION
This allows to not depend on the underlying  TH1/TH2 type when plotting Micromegas QA histogram.
+ some minor cleanup.
