### PR TITLE
Fix labels/titles, split pages into no more than 4 histograms

### DIFF
--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -222,13 +222,9 @@ int JetDraw::DrawRho(const uint32_t trigToDraw /*const JetRes resToDraw*/)
     eventwiserho_rhoarea->SetTitle("Rho Area");
     eventwiserho_rhoarea->SetXTitle("#rho*A");
     eventwiserho_rhoarea->SetYTitle("Counts");
-    // eventwiserho_rhoarea->GetXaxis()->SetNdivisions(505);
-    // eventwiserho_rhoarea->GetXaxis()->SetRangeUser(-1, 15);
     eventwiserho_rhoarea->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
-    gPad->SetLogy();
-    gPad->SetLogz();
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -244,7 +240,7 @@ int JetDraw::DrawRho(const uint32_t trigToDraw /*const JetRes resToDraw*/)
     eventwiserho_rhomult->SetYTitle("Counts");
     eventwiserho_rhomult->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -258,10 +254,9 @@ int JetDraw::DrawRho(const uint32_t trigToDraw /*const JetRes resToDraw*/)
     eventwiserho_sigmaarea->SetTitle("Sigma Area");
     eventwiserho_sigmaarea->SetXTitle("#sigma*A");
     eventwiserho_sigmaarea->SetYTitle("Counts");
-    // eventwiserho_sigmaarea->GetXaxis()->SetNdivisions(505);
     eventwiserho_sigmaarea->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -277,6 +272,7 @@ int JetDraw::DrawRho(const uint32_t trigToDraw /*const JetRes resToDraw*/)
     eventwiserho_sigmamult->SetYTitle("Counts");
     eventwiserho_sigmamult->DrawCopy("COLZ");
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
   else
   {
@@ -360,13 +356,9 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_ncsts_cemc->SetTitle("Jet N Constituents in CEMC");
     constituents_ncsts_cemc->SetXTitle("N Constituents");
     constituents_ncsts_cemc->SetYTitle("Counts");
-    constituents_ncsts_cemc->GetXaxis()->SetNdivisions(505);
-    constituents_ncsts_cemc->GetXaxis()->SetRangeUser(-1, 15);
     constituents_ncsts_cemc->DrawCopy("HIST"); //1D histogram
     gPad->UseCurrentStyle();
-    gPad->SetLogy();
-    //gPad->SetLogz() //No z axis
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -383,7 +375,7 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_ncsts_ihcal->GetXaxis()->SetNdivisions(505);
     constituents_ncsts_ihcal->DrawCopy("HIST"); // 1D histogram
     gPad->UseCurrentStyle();
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -400,7 +392,7 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_ncsts_ohcal->GetXaxis()->SetNdivisions(505);
     constituents_ncsts_ohcal->DrawCopy("HIST"); // 1D Histogram                             
     gPad->UseCurrentStyle();
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -417,6 +409,7 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_ncsts_total->SetYTitle("Counts");
     constituents_ncsts_total->DrawCopy("HIST"); // 1D Histogram
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
   else
   {
@@ -434,7 +427,8 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_ncstsvscalolayer->DrawCopy("COLZ"); // 2D Histogram
     gPad->UseCurrentStyle();
     gPad->Update();
-    gPad->SetRightMargin(0.15);
+    gPad->SetRightMargin(0.2);
+    gPad->SetLogz(1);
   }
   else
   {
@@ -452,7 +446,8 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_efracjetvscalolayer->DrawCopy("COLZ"); // 2D Histogram
     gPad->UseCurrentStyle();
     gPad->Update();
-    gPad->SetRightMargin(0.15);
+    gPad->SetRightMargin(0.2);
+    gPad->SetLogz(1);
   }
   else
   {
@@ -468,8 +463,7 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_efracjet_cemc->SetYTitle("Counts");
     constituents_efracjet_cemc->DrawCopy("HIST"); // 1D Histogram
     gPad->UseCurrentStyle();
-    gPad->Update();
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -485,8 +479,7 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_efracjet_ihcal->SetYTitle("Counts");
     constituents_efracjet_ihcal->DrawCopy("HIST"); // 1D Histogram
     gPad->UseCurrentStyle();
-    gPad->Update();
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -503,7 +496,7 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_efracjet_ohcal->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
     gPad->Update();
-    gPad->SetRightMargin(0.15);
+    gPad->SetLogy(1);
   }
   else
   {
@@ -592,7 +585,8 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     jetkinematiccheck_etavsphi->DrawCopy("COLZ");  // 2D Histogram
     gPad->UseCurrentStyle();
     gPad->Update();
-    gPad->SetRightMargin(0.15);
+    gPad->SetRightMargin(0.2);
+    gPad->SetLogz(1);
   }
   else
   {
@@ -615,7 +609,8 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     jetkinematiccheck_jetmassvseta_pfx->DrawCopy("SAME");  // Profile
     gPad->UseCurrentStyle();
     gPad->Update();
-    gPad->SetRightMargin(0.15);
+    gPad->SetRightMargin(0.2);
+    gPad->SetLogz(1);
   }
   else
   {
@@ -638,7 +633,8 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     jetkinematiccheck_jetmassvspt_pfx->DrawCopy("SAME");  // Profile
     gPad->UseCurrentStyle();
     gPad->Update();
-    gPad->SetRightMargin(0.15);
+    gPad->SetRightMargin(0.2);
+    gPad->SetLogz(1);
   }
   else
   {
@@ -654,6 +650,7 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     jetkinematiccheck_spectra->SetYTitle("Counts");
     jetkinematiccheck_spectra->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
   else
   {
@@ -744,6 +741,8 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
       // jetseedcount_rawetavsphi->GetXaxis()->SetNdivisions(505);
       jetseedcount_rawetavsphi->DrawCopy("COLZ");  // 2D Histogram
       gPad->UseCurrentStyle();
+      gPad->SetRightMargin(0.2);
+      gPad->SetLogz(1);
   }
   else
   {
@@ -759,6 +758,7 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
     jetseedcount_rawpt->SetYTitle("Counts");
     jetseedcount_rawpt->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
   else
   {
@@ -774,6 +774,7 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
     jetseedcount_rawptall->SetYTitle("Counts");
     jetseedcount_rawptall->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
   else
   {
@@ -789,6 +790,7 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
     jetseedcount_rawseedcount->SetYTitle("Counts");
     jetseedcount_rawseedcount->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
   else
   {
@@ -800,14 +802,14 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
   if (jetseedcount_subetavsphi)
   {
     jetseedcount_subetavsphi->SetLineColor(kBlue);
-    // jetseedcount_subetavsphi->GetXaxis()->SetRangeUser(0.0, 12000);
     jetseedcount_subetavsphi->SetTitle("Sub-seed #eta vs #phi");
     jetseedcount_subetavsphi->SetXTitle("Jet #eta_{subseed} [Rads.]");
     jetseedcount_subetavsphi->SetYTitle("Jet #phi_{subseed} [Rads.]");
     jetseedcount_subetavsphi->SetZTitle("Counts");
-    // jetseedcount_subetavsphi->GetXaxis()->SetNdivisions(505);
     jetseedcount_subetavsphi->DrawCopy("COLZ");  // 2D Histogram
     gPad->UseCurrentStyle();
+    gPad->SetRightMargin(0.2);
+    gPad->SetLogz(1);
   }
   else
   {
@@ -822,6 +824,7 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
     jetseedcount_subpt->SetYTitle("Counts");
     jetseedcount_subpt->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
   else
   {
@@ -836,6 +839,7 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
     jetseedcount_subptall->SetYTitle("Counts");
     jetseedcount_subptall->DrawCopy("HIST");  // 1D Histogram
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
   else
   {
@@ -850,6 +854,7 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
     jetseedcount_subseedcount->SetYTitle("Counts");
     jetseedcount_subseedcount->DrawCopy("");
     gPad->UseCurrentStyle();
+    gPad->SetLogy(1);
   }
 
   TText PrintRun;

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -890,7 +890,7 @@ void JetDraw::DrawHists(
     }
     else
     {
-      /* TODO draw empty hist here */
+      DrawEmptyHistogram(hists.at(indices[iPad]).title);
     }
   }
 
@@ -899,6 +899,30 @@ void JetDraw::DrawHists(
   plots.back().canvas->Update();
 
 }  // end 'DrawHists(std::string&, std::vector<std:size_t>&, VHistAndOpts1D&, VPlotPads1D&, int x 2)'
+
+// ----------------------------------------------------------------------------
+//! Draw empty histogram on current pad
+// ----------------------------------------------------------------------------
+/*! Helper function to draw an empty histogram on the current
+ *  pad. Used when a histogram is missing.
+ *
+ *  \param[in] what what's missing (e.g. a histogram)
+ */
+void JetDraw::DrawEmptyHistogram(const std::string& what = "histogram")
+{
+
+  // set up hist/text
+  TH1D*   hEmpty = new TH1D("hEmpty", "", 10, 0, 10);
+  TLatex* lEmpty = new TLatex();
+
+  // set up message
+  const std::string message = what + " is missing";
+
+  // and draw them on current pad
+  hEmpty->DrawCopy();
+  lEmpty->DrawLatex(0.3, 0.5, message.data());
+
+}  // end 'DrawEmptyHistogram()'
 
 // ----------------------------------------------------------------------------
 //! Update style of current pad based on options

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -372,7 +372,6 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_ncsts_ihcal->SetTitle("Jet N Constituents in IHCal");
     constituents_ncsts_ihcal->SetXTitle("N Constituents");
     constituents_ncsts_ihcal->SetYTitle("Counts");
-    constituents_ncsts_ihcal->GetXaxis()->SetNdivisions(505);
     constituents_ncsts_ihcal->DrawCopy("HIST"); // 1D histogram
     gPad->UseCurrentStyle();
     gPad->SetLogy(1);
@@ -389,7 +388,6 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     constituents_ncsts_ohcal->SetTitle("Jet N Constituents in OHCal");
     constituents_ncsts_ohcal->SetXTitle("N Constituents");
     constituents_ncsts_ohcal->SetYTitle("Counts");
-    constituents_ncsts_ohcal->GetXaxis()->SetNdivisions(505);
     constituents_ncsts_ohcal->DrawCopy("HIST"); // 1D Histogram                             
     gPad->UseCurrentStyle();
     gPad->SetLogy(1);
@@ -405,7 +403,6 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
   {
     constituents_ncsts_total->SetTitle("Jet N Constituents");
     constituents_ncsts_total->SetXTitle("N Constituents");
-    constituents_ncsts_total->GetXaxis()->SetNdivisions(505);
     constituents_ncsts_total->SetYTitle("Counts");
     constituents_ncsts_total->DrawCopy("HIST"); // 1D Histogram
     gPad->UseCurrentStyle();
@@ -563,7 +560,7 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
   TH2D *jetkinematiccheck_etavsphi = dynamic_cast<TH2D *>(cl->getHisto(kineHistPrefix + "_etavsphi_" + m_mapResToTag[resToDraw]));
   TH2D *jetkinematiccheck_jetmassvseta = dynamic_cast<TH2D *>(cl->getHisto(kineHistPrefix + "_jetmassvseta_" + m_mapResToTag[resToDraw]));
   TH2D *jetkinematiccheck_jetmassvspt = dynamic_cast<TH2D *>(cl->getHisto(kineHistPrefix + "_jetmassvspt_" + m_mapResToTag[resToDraw]));
-  TH2D *jetkinematiccheck_spectra = dynamic_cast<TH2D *>(cl->getHisto(kineHistPrefix + "_spectra_" + m_mapResToTag[resToDraw]));
+  TH1D *jetkinematiccheck_spectra = dynamic_cast<TH1D *>(cl->getHisto(kineHistPrefix + "_spectra_" + m_mapResToTag[resToDraw]));
 
   TProfile *jetkinematiccheck_jetmassvseta_pfx = dynamic_cast<TProfile *>(cl->getHisto(kineHistPrefix + "_jetmassvseta_" + kineProfSuffix));
   TProfile *jetkinematiccheck_jetmassvspt_pfx = dynamic_cast<TProfile *>(cl->getHisto(kineHistPrefix + "_jetmassvspt_" + kineProfSuffix));
@@ -904,8 +901,8 @@ void JetDraw::SetJetSummary(TCanvas* c)
    TText PrintRun;
    PrintRun.SetTextFont(62);
    PrintRun.SetTextSize(0.04);
-   PrintRun.SetNDC();          // set to normalized coordinates                                                                                                                                                                                                                  
-   PrintRun.SetTextAlign(23);  // center/top alignment                                                                                                                                                                                                                           
+   PrintRun.SetNDC();          // set to normalized coordinates
+   PrintRun.SetTextAlign(23);  // center/top alignment
    std::ostringstream runnostream;
    std::string runstring;
    runnostream << Name() << "_jet_summary Run " << cl->RunNumber() << ", build " << cl->build();

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -589,8 +589,6 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     jetkinematiccheck_etavsphi->SetXTitle("Jet #eta");
     jetkinematiccheck_etavsphi->SetYTitle("Jet #phi");
     jetkinematiccheck_etavsphi->SetZTitle("Counts");
-    // jetkinematiccheck_etavsphi->GetXaxis()->SetNdivisions(505);
-    // jetkinematiccheck_etavsphi->GetXaxis()->SetRangeUser(-1, 15);
     jetkinematiccheck_etavsphi->DrawCopy("COLZ");  // 2D Histogram
     gPad->UseCurrentStyle();
     gPad->Update();
@@ -606,13 +604,13 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
   if (jetkinematiccheck_jetmassvseta && jetkinematiccheck_jetmassvseta_pfx)
   {
     jetkinematiccheck_jetmassvseta->SetTitle("Jet Mass vs #eta");
-    jetkinematiccheck_jetmassvseta->SetXTitle("Jet Mass [GeV/c^{2}]");
-    jetkinematiccheck_jetmassvseta->SetYTitle("Jet #eta");
+    jetkinematiccheck_jetmassvseta->SetXTitle("Jet #eta");
+    jetkinematiccheck_jetmassvseta->SetYTitle("Jet Mass [GeV/c^{2}]");
     jetkinematiccheck_jetmassvseta->SetZTitle("Counts");
     jetkinematiccheck_jetmassvseta->DrawCopy("COLZ");  // 2D Histogram
     jetkinematiccheck_jetmassvseta_pfx->SetTitle("Jet Mass vs #eta");
-    jetkinematiccheck_jetmassvseta_pfx->SetXTitle("Jet Mass [GeV/c^{2}]");
-    jetkinematiccheck_jetmassvseta_pfx->SetYTitle("Jet #eta");
+    jetkinematiccheck_jetmassvseta_pfx->SetXTitle("Jet #eta");
+    jetkinematiccheck_jetmassvseta_pfx->SetYTitle("Jet Mass [GeV/c^{2}]");
     jetkinematiccheck_jetmassvseta_pfx->SetZTitle("Counts");
     jetkinematiccheck_jetmassvseta_pfx->DrawCopy("SAME");  // Profile
     gPad->UseCurrentStyle();
@@ -629,13 +627,13 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
   if (jetkinematiccheck_jetmassvspt && jetkinematiccheck_jetmassvspt_pfx)
   {
     jetkinematiccheck_jetmassvspt->SetTitle("Jet Mass vs p_{T}");
-    jetkinematiccheck_jetmassvspt->SetXTitle("Jet Mass [GeV/c^{2}]");
-    jetkinematiccheck_jetmassvspt->SetYTitle("Jet p_{T} [GeV/c]");
+    jetkinematiccheck_jetmassvspt->SetXTitle("Jet p_{T} [GeV/c]");
+    jetkinematiccheck_jetmassvspt->SetYTitle("Jet Mass [GeV/c^{2}]");
     jetkinematiccheck_jetmassvspt->SetZTitle("Counts");
     jetkinematiccheck_jetmassvspt->DrawCopy("COLZ");  // 2D Histogram
     jetkinematiccheck_jetmassvspt_pfx->SetTitle("Jet Mass vs p_{T}");
-    jetkinematiccheck_jetmassvspt_pfx->SetXTitle("Jet Mass [GeV/c^{2}]");
-    jetkinematiccheck_jetmassvspt_pfx->SetYTitle("Jet p_{T} [GeV/c]");
+    jetkinematiccheck_jetmassvspt_pfx->SetXTitle("Jet p_{T} [GeV/c]");
+    jetkinematiccheck_jetmassvspt_pfx->SetYTitle("Jet Mass [GeV/c^{2}]");
     jetkinematiccheck_jetmassvspt_pfx->SetZTitle("Counts");
     jetkinematiccheck_jetmassvspt_pfx->DrawCopy("SAME");  // Profile
     gPad->UseCurrentStyle();

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -79,7 +79,8 @@ class JetDraw : public QADraw
     int DrawJetSeed(uint32_t trigger, JetRes reso);
     void DrawRunAndBuild(const std::string& what, TPad* pad, const int trig = -1, const int res = -1);
     void DrawHists(const std::string& what, const std::vector<std::size_t>& indices, const JetDrawDefs::VHistAndOpts1D& hists, JetDrawDefs::VPlotPads1D& plots, const int trig = -1, const int res = -1);
-    void DrawEmptyHistogram(const std::string& what);
+    void DrawHistOnPad(const std::size_t iHist, const std::size_t iPad, const JetDrawDefs::VHistAndOpts1D& hists, JetDrawDefs::PlotPads& plot);
+    void DrawEmptyHistogram(const std::string& what = "histogram");
     void MakeCanvas(const std::string& name, const int nHist, JetDrawDefs::VPlotPads1D& plots);
     void UpdatePadStyle(const JetDrawDefs::HistAndOpts& hist);
     void myText(double x, double y, int color, const char* text, double tsize = 0.04);

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -87,6 +87,7 @@ class JetDraw : public QADraw
     void MakeCanvas(const std::string &name, const int nHist, VPlotPads1D& plots);
     void DrawRunAndBuild(const std::string& what, TPad* pad, const int trig = -1, const int res = -1);
     void DrawHists(const std::string& what, const std::vector<std::size_t>& indices, const VHistAndOpts1D& hists, VPlotPads1D& plots, const int trig = -1, const int res = -1);
+    void DrawEmptyHistogram(const std::string& what);
     void UpdatePadStyle(const HistAndOpts& hist);
     void myText(double x, double y, int color, const char *text, double tsize = 0.04);
 

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -46,11 +46,12 @@ class JetDraw : public QADraw
   void SaveCanvasesToFile(TFile* file);
 
  private:
-  int MakeCanvas(const std::string &name, const int nHist, VCanvas1D& canvas, VPad1D& run);
+  int MakeCanvas(const std::string &name, const int nHist, VCanvas1D& canvas, VPad1D& hist, VPad1D& run);
   int DrawRho(uint32_t trigger);
   int DrawConstituents(uint32_t trigToDraw, JetRes resToDraw);
   int DrawJetKinematics(uint32_t trigger, JetRes reso);
   int DrawJetSeed(uint32_t trigger, JetRes reso);
+  int DrawRunAndBuild(TPad* pad, const std::string what, const int trig = -1, const int res = -1);
   void myText(double x, double y, int color, const char *text, double tsize = 0.04);
 
   TCanvas* jetSummary = nullptr;
@@ -60,6 +61,12 @@ class JetDraw : public QADraw
   VCanvas2D m_vecCstCanvas;
   VCanvas2D m_vecKineCanvas;
   VCanvas2D m_vecSeedCanvas;
+
+  // for adding histograms to canvases
+  VPad1D m_vecRhoHist;
+  VPad2D m_vecCstHist;
+  VPad2D m_vecKineHist;
+  VPad2D m_vecSeedHist;
 
   // for adding run numbers to canvases
   VPad1D m_vecRhoRun;

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -1,10 +1,12 @@
 #ifndef JET_DRAW_H
 #define JET_DRAW_H
 
+#include "JetDrawDefs.h"
 #include <qahtml/QADrawClient.h>
 #include <qahtml/QADraw.h>
 #include <jetqa/JetQADefs.h>
 #include <map>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -17,50 +19,20 @@ class TH1;
 class TH2;
 class TPad;
 
-// aliases for convenience
-using VPad1D    = std::vector<TPad*>;
-using VPad2D    = std::vector<std::vector<TPad*>>;
-using VCanvas1D = std::vector<TCanvas*>;
-using VCanvas2D = std::vector<std::vector<TCanvas*>>;
-
+// ============================================================================
+//! Draw jet QA histograms
+// ============================================================================
+/*! A QAhtml subsystem to draw jet QA histograms
+ *  and generate relevant HTML pages.
+ */
 class JetDraw : public QADraw
 {
   public:
 
-    // ------------------------------------------------------------------------
-    //! Helper struct to consolidate pads for drawing
-    // ------------------------------------------------------------------------
-    struct PlotPads
-    {
-      TCanvas* canvas  {nullptr};  ///< canvas to draw on
-      TPad*    histPad {nullptr};  ///< pad for histograms
-      TPad*    runPad  {nullptr};  ///< pad for run/build info
-    };  // end PlotPads
-
-    // vector of plot pads
-    typedef std::vector<PlotPads> VPlotPads1D;
-    typedef std::vector<std::vector<PlotPads>> VPlotPads2D;
-    typedef std::vector<std::vector<std::vector<PlotPads>>> VPlotPads3D;
-
-    // ------------------------------------------------------------------------
-    //! Helper struct to consolidate histogram and drawing options
-    // ------------------------------------------------------------------------
-    struct HistAndOpts
-    {
-      TH1*        hist   {nullptr}; ///< histogram
-      std::string title  {""};      ///< histogram title
-      std::string titlex {""};      ///< x-axis title
-      std::string titley {""};      ///< y-axis title
-      std::string titlez {""};      ///< z-axis title
-      float       margin {0.25};    ///< right margin of pad
-      bool        logy   {false};   ///< make y axis log
-      bool        logz   {false};   ///< make z axis log
-    };  // end HistAndOpts
-
-    // vector of histogram and options
-    typedef std::vector<HistAndOpts> VHistAndOpts1D;
-
-    // tags for jet resolutions
+    // ========================================================================
+    //! Tags for jet resolutions
+    // ========================================================================
+    /*! Enumerates possible jet resolutions to plot. */
     enum JetRes
     {
       R02,
@@ -69,48 +41,83 @@ class JetDraw : public QADraw
       R05
     };
 
+    // ctor/dtor
     JetDraw(const std::string &name = "JetQA");
     ~JetDraw() override;
-    int MakeHtml(const std::string &what = "ALL") override;
-    int Draw(const std::string &what = "ALL") override;
+
+    // setters
+    void SetDoDebug(const bool debug) {m_do_debug = debug;}
+    void SetJetType(const std::string& type) {m_jet_type = type;}
+    void SetRhoPrefix(const std::string& prefix) {m_rho_prefix = prefix;}
+    void SetCstPrefix(const std::string& prefix) {m_constituent_prefix = prefix;}
+    void SetKinePrefix(const std::string& prefix) {m_kinematic_prefix = prefix;}
+    void SetSeedPrefix(const std::string& prefix) {m_seed_prefix = prefix;}
+
+    // getters 
+    bool GetDoDebug() const {return m_do_debug;}
+    std::string GetJetType() const {return m_jet_type;}
+    std::string GetRhoPrefix() const {return m_rho_prefix;}
+    std::string GetCstPrefix() const {return m_constituent_prefix;}
+    std::string GetKinePrefix() const {return m_kinematic_prefix;}
+    std::string GetSeedPrefix() const {return m_seed_prefix;}
+
+    // inherited public methods
+    int Draw(const std::string& what = "ALL") override;
+    int MakeHtml(const std::string& what = "ALL") override;
+
+    // other public methods
     int DBVarInit();
     void SetJetSummary(TCanvas* c);
-    void SetDoDebug(const bool debug);
     void SaveCanvasesToFile(TFile* file);
 
   private:
 
+    // private methods
     int DrawRho(uint32_t trigger);
     int DrawConstituents(uint32_t trigToDraw, JetRes resToDraw);
     int DrawJetKinematics(uint32_t trigger, JetRes reso);
     int DrawJetSeed(uint32_t trigger, JetRes reso);
-    void MakeCanvas(const std::string &name, const int nHist, VPlotPads1D& plots);
     void DrawRunAndBuild(const std::string& what, TPad* pad, const int trig = -1, const int res = -1);
-    void DrawHists(const std::string& what, const std::vector<std::size_t>& indices, const VHistAndOpts1D& hists, VPlotPads1D& plots, const int trig = -1, const int res = -1);
+    void DrawHists(const std::string& what, const std::vector<std::size_t>& indices, const JetDrawDefs::VHistAndOpts1D& hists, JetDrawDefs::VPlotPads1D& plots, const int trig = -1, const int res = -1);
     void DrawEmptyHistogram(const std::string& what);
-    void UpdatePadStyle(const HistAndOpts& hist);
-    void myText(double x, double y, int color, const char *text, double tsize = 0.04);
+    void MakeCanvas(const std::string& name, const int nHist, JetDrawDefs::VPlotPads1D& plots);
+    void UpdatePadStyle(const JetDrawDefs::HistAndOpts& hist);
+    void myText(double x, double y, int color, const char* text, double tsize = 0.04);
 
-    TCanvas* jetSummary = nullptr;
-
-    // canvas/pads for drawing
-    VPlotPads2D m_rhoPlots;
-    VPlotPads3D m_cstPlots;
-    VPlotPads3D m_kinePlots;
-    VPlotPads3D m_seedPlots;
-
-    // turn debugging statements on/off
+    ///! turn debugging statements on/off
     bool m_do_debug;
 
-    const char* m_constituent_prefix;
-    const char* m_rho_prefix;
-    const char* m_kinematic_prefix;
-    const char* m_seed_prefix;
+    ///! type of jet input, used in histogram names
+    std::string m_jet_type;
 
-    // jet type (TODO will need to expand this to a vector in the future)
-    const char* m_jet_type;
+    ///! prefix of event-wise rho qa histograms
+    std::string m_rho_prefix;
 
-    // triggers we want to draw
+    ///! prefix of constituent qa histograms 
+    std::string m_constituent_prefix;
+
+    ///! prefix of jet kinematic qa histograms
+    std::string m_kinematic_prefix;
+
+    ///! prefix of jet seed qa histograms
+    std::string m_seed_prefix;
+
+    ///! summary of overall jet qa goodness
+    TCanvas* m_jetSummary{nullptr};
+
+    ///! event-wise rho canvases
+    JetDrawDefs::VPlotPads2D m_rhoPlots;
+
+    ///! constituent canvases
+    JetDrawDefs::VPlotPads3D m_cstPlots;
+
+    ///! jet kinematic canvases
+    JetDrawDefs::VPlotPads3D m_kinePlots;
+
+    ///! jet seed canvases
+    JetDrawDefs::VPlotPads3D m_seedPlots;
+
+    ///! triggers we want to draw
     std::vector<uint32_t> m_vecTrigToDraw = {
       JetQADefs::GL1::MBDNSJet1,
       JetQADefs::GL1::MBDNSJet2,
@@ -118,7 +125,7 @@ class JetDraw : public QADraw
       JetQADefs::GL1::MBDNSJet4
     };
 
-    // resolutions we want to draw
+    ///! resolutions we want to draw
     std::vector<uint32_t> m_vecResToDraw = {
       JetRes::R02,
       JetRes::R03,
@@ -126,7 +133,7 @@ class JetDraw : public QADraw
       JetRes::R05
     };
 
-    // map of resolution index to name
+    ///! map of resolution index to name
     std::map<uint32_t, std::string> m_mapResToName = {
       {JetRes::R02, "Res02"},
       {JetRes::R03, "Res03"},
@@ -134,7 +141,7 @@ class JetDraw : public QADraw
       {JetRes::R05, "Res05"}
     };
 
-    //map res to Tag
+    ///! map of resultion index to tag
     std::map<uint32_t, std::string> m_mapResToTag = {
       {JetRes::R02, "r02"},
       {JetRes::R03, "r03"},
@@ -142,7 +149,7 @@ class JetDraw : public QADraw
       {JetRes::R05, "r05"}
     };
 
-    // map of trigger index onto name
+    ///! map of trigger index onto name
     std::map<uint32_t, std::string> m_mapTrigToName = {
       {JetQADefs::GL1::MBDNSJet1, "JetCoin6GeV"},
       {JetQADefs::GL1::MBDNSJet2, "JetCoin8GeV"},
@@ -150,7 +157,7 @@ class JetDraw : public QADraw
       {JetQADefs::GL1::MBDNSJet4, "JetCoin12GeV"}
     };
 
-    // map trig to tag
+    ///! map trig to tag (FIXME use those from Jet_QA.C)
     std::map<uint32_t, std::string> m_mapTrigToTag = {
       {JetQADefs::GL1::MBDNS1, "mbdns1"},
       {JetQADefs::GL1::MBDNSJet1, "mbdnsjet1"},
@@ -158,7 +165,6 @@ class JetDraw : public QADraw
       {JetQADefs::GL1::MBDNSJet3, "mbdnsjet3"},
       {JetQADefs::GL1::MBDNSJet4, "mbdnsjet4"}
     };
-
-};  // end JetDraw
+};
 
 #endif

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -25,113 +25,139 @@ using VCanvas2D = std::vector<std::vector<TCanvas*>>;
 
 class JetDraw : public QADraw
 {
- public:
+  public:
 
-  // tags for jet resolutions
-  enum JetRes
-  {
-    R02,
-    R03,
-    R04,
-    R05
-  };
+    // ------------------------------------------------------------------------
+    //! Helper struct to consolidate pads for drawing
+    // ------------------------------------------------------------------------
+    struct PlotPads
+    {
+      TCanvas* canvas  {nullptr};  ///< canvas to draw on
+      TPad*    histPad {nullptr};  ///< pad for histograms
+      TPad*    runPad  {nullptr};  ///< pad for run/build info
+    };  // end PlotPads
 
-  JetDraw(const std::string &name = "JetQA");
-  ~JetDraw() override;
-  int MakeHtml(const std::string &what = "ALL") override;
-  int Draw(const std::string &what = "ALL") override;
-  int DBVarInit();
-  void SetJetSummary(TCanvas* c);
-  void SetDoDebug(const bool debug);
-  void SaveCanvasesToFile(TFile* file);
+    // vector of plot pads
+    typedef std::vector<PlotPads> VPlotPads1D;
+    typedef std::vector<std::vector<PlotPads>> VPlotPads2D;
+    typedef std::vector<std::vector<std::vector<PlotPads>>> VPlotPads3D;
 
- private:
-  int MakeCanvas(const std::string &name, const int nHist, VCanvas1D& canvas, VPad1D& hist, VPad1D& run);
-  int DrawRho(uint32_t trigger);
-  int DrawConstituents(uint32_t trigToDraw, JetRes resToDraw);
-  int DrawJetKinematics(uint32_t trigger, JetRes reso);
-  int DrawJetSeed(uint32_t trigger, JetRes reso);
-  int DrawRunAndBuild(TPad* pad, const std::string what, const int trig = -1, const int res = -1);
-  void myText(double x, double y, int color, const char *text, double tsize = 0.04);
+    // ------------------------------------------------------------------------
+    //! Helper struct to consolidate histogram and drawing options
+    // ------------------------------------------------------------------------
+    struct HistAndOpts
+    {
+      TH1*        hist   {nullptr}; ///< histogram
+      std::string title  {""};      ///< histogram title
+      std::string titlex {""};      ///< x-axis title
+      std::string titley {""};      ///< y-axis title
+      std::string titlez {""};      ///< z-axis title
+      float       margin {0.25};    ///< right margin of pad
+      bool        logy   {false};   ///< make y axis log
+      bool        logz   {false};   ///< make z axis log
+    };  // end HistAndOpts
 
-  TCanvas* jetSummary = nullptr;
+    // vector of histogram and options
+    typedef std::vector<HistAndOpts> VHistAndOpts1D;
 
-  // canvases for drawing
-  VCanvas1D m_vecRhoCanvas;
-  VCanvas2D m_vecCstCanvas;
-  VCanvas2D m_vecKineCanvas;
-  VCanvas2D m_vecSeedCanvas;
+    // tags for jet resolutions
+    enum JetRes
+    {
+      R02,
+      R03,
+      R04,
+      R05
+    };
 
-  // for adding histograms to canvases
-  VPad1D m_vecRhoHist;
-  VPad2D m_vecCstHist;
-  VPad2D m_vecKineHist;
-  VPad2D m_vecSeedHist;
+    JetDraw(const std::string &name = "JetQA");
+    ~JetDraw() override;
+    int MakeHtml(const std::string &what = "ALL") override;
+    int Draw(const std::string &what = "ALL") override;
+    int DBVarInit();
+    void SetJetSummary(TCanvas* c);
+    void SetDoDebug(const bool debug);
+    void SaveCanvasesToFile(TFile* file);
 
-  // for adding run numbers to canvases
-  VPad1D m_vecRhoRun;
-  VPad2D m_vecCstRun;
-  VPad2D m_vecKineRun;
-  VPad2D m_vecSeedRun;
+  private:
 
-  // turn debugging statements on/off
-  bool m_do_debug;
+    int DrawRho(uint32_t trigger);
+    int DrawConstituents(uint32_t trigToDraw, JetRes resToDraw);
+    int DrawJetKinematics(uint32_t trigger, JetRes reso);
+    int DrawJetSeed(uint32_t trigger, JetRes reso);
+    void MakeCanvas(const std::string &name, const int nHist, VPlotPads1D& plots);
+    void DrawRunAndBuild(const std::string& what, TPad* pad, const int trig = -1, const int res = -1);
+    void DrawHists(const std::string& what, const std::vector<std::size_t>& indices, const VHistAndOpts1D& hists, VPlotPads1D& plots, const int trig = -1, const int res = -1);
+    void UpdatePadStyle(const HistAndOpts& hist);
+    void myText(double x, double y, int color, const char *text, double tsize = 0.04);
 
-  const char* m_constituent_prefix;
-  const char* m_rho_prefix;
-  const char* m_kinematic_prefix;
-  const char* m_seed_prefix;
+    TCanvas* jetSummary = nullptr;
 
-  // jet type (TODO will need to expand this to a vector in the future)
-  const char* m_jet_type;
+    // canvas/pads for drawing
+    VPlotPads2D m_rhoPlots;
+    VPlotPads3D m_cstPlots;
+    VPlotPads3D m_kinePlots;
+    VPlotPads3D m_seedPlots;
 
-  // triggers we want to draw
-  std::vector<uint32_t> m_vecTrigToDraw = {
-    JetQADefs::GL1::MBDNSJet1,
-    JetQADefs::GL1::MBDNSJet2,
-    JetQADefs::GL1::MBDNSJet3,
-    JetQADefs::GL1::MBDNSJet4
-  };
+    // turn debugging statements on/off
+    bool m_do_debug;
 
-  // resolutions we want to draw
-  std::vector<uint32_t> m_vecResToDraw = {
-    JetRes::R02,
-    JetRes::R03,
-    JetRes::R04,
-    JetRes::R05
-  };
+    const char* m_constituent_prefix;
+    const char* m_rho_prefix;
+    const char* m_kinematic_prefix;
+    const char* m_seed_prefix;
 
-  // map of resolution index to name
-  std::map<uint32_t, std::string> m_mapResToName = {
-    {JetRes::R02, "Res02"},
-    {JetRes::R03, "Res03"},
-    {JetRes::R04, "Res04"},
-    {JetRes::R05, "Res05"}
-  };
+    // jet type (TODO will need to expand this to a vector in the future)
+    const char* m_jet_type;
 
-  //map res to Tag
-  std::map<uint32_t, std::string> m_mapResToTag = {
-    {JetRes::R02, "r02"},
-    {JetRes::R03, "r03"},
-    {JetRes::R04, "r04"},
-    {JetRes::R05, "r05"}
-  };
+    // triggers we want to draw
+    std::vector<uint32_t> m_vecTrigToDraw = {
+      JetQADefs::GL1::MBDNSJet1,
+      JetQADefs::GL1::MBDNSJet2,
+      JetQADefs::GL1::MBDNSJet3,
+      JetQADefs::GL1::MBDNSJet4
+    };
 
-  // map of trigger index onto name
-  std::map<uint32_t, std::string> m_mapTrigToName = {
-    {JetQADefs::GL1::MBDNSJet1, "JetCoin6GeV"},
-    {JetQADefs::GL1::MBDNSJet2, "JetCoin8GeV"},
-    {JetQADefs::GL1::MBDNSJet3, "JetCoin10GeV"},
-    {JetQADefs::GL1::MBDNSJet4, "JetCoin12GeV"}
-  };
+    // resolutions we want to draw
+    std::vector<uint32_t> m_vecResToDraw = {
+      JetRes::R02,
+      JetRes::R03,
+      JetRes::R04,
+      JetRes::R05
+    };
 
-  // map trig to tag
-  std::map<uint32_t, std::string> m_mapTrigToTag = {
-    {JetQADefs::GL1::MBDNS1, "mbdns1"},
-    {JetQADefs::GL1::MBDNSJet1, "mbdnsjet1"},
-    {JetQADefs::GL1::MBDNSJet2, "mbdnsjet2"},
-    {JetQADefs::GL1::MBDNSJet3, "mbdnsjet3"},
-    {JetQADefs::GL1::MBDNSJet4, "mbdnsjet4"}
-  };
-};
+    // map of resolution index to name
+    std::map<uint32_t, std::string> m_mapResToName = {
+      {JetRes::R02, "Res02"},
+      {JetRes::R03, "Res03"},
+      {JetRes::R04, "Res04"},
+      {JetRes::R05, "Res05"}
+    };
+
+    //map res to Tag
+    std::map<uint32_t, std::string> m_mapResToTag = {
+      {JetRes::R02, "r02"},
+      {JetRes::R03, "r03"},
+      {JetRes::R04, "r04"},
+      {JetRes::R05, "r05"}
+    };
+
+    // map of trigger index onto name
+    std::map<uint32_t, std::string> m_mapTrigToName = {
+      {JetQADefs::GL1::MBDNSJet1, "JetCoin6GeV"},
+      {JetQADefs::GL1::MBDNSJet2, "JetCoin8GeV"},
+      {JetQADefs::GL1::MBDNSJet3, "JetCoin10GeV"},
+      {JetQADefs::GL1::MBDNSJet4, "JetCoin12GeV"}
+    };
+
+    // map trig to tag
+    std::map<uint32_t, std::string> m_mapTrigToTag = {
+      {JetQADefs::GL1::MBDNS1, "mbdns1"},
+      {JetQADefs::GL1::MBDNSJet1, "mbdnsjet1"},
+      {JetQADefs::GL1::MBDNSJet2, "mbdnsjet2"},
+      {JetQADefs::GL1::MBDNSJet3, "mbdnsjet3"},
+      {JetQADefs::GL1::MBDNSJet4, "mbdnsjet4"}
+    };
+
+};  // end JetDraw
+
 #endif

--- a/subsystems/jets/JetDrawDefs.h
+++ b/subsystems/jets/JetDrawDefs.h
@@ -1,0 +1,53 @@
+// Derek Anderson <ruse-traveler@github.com>
+
+#ifndef JET_DRAW_DEFS_H
+#define JET_DRAW_DEFS_H
+
+#include <TCanvas.h>
+#include <TH1.h>
+#include <TPad.h>
+#include <string>
+#include <vector>
+
+// ============================================================================
+//! Misc. definitions for the JetDraw QAhtml subsystem
+// ============================================================================ 
+namespace JetDrawDefs
+{
+
+  // ========================================================================
+  //! Helper struct to consolidate pads for drawing
+  // ========================================================================
+  struct PlotPads
+  {
+    TCanvas* canvas  {nullptr};  ///< canvas to draw on
+    TPad*    histPad {nullptr};  ///< pad for histograms
+    TPad*    runPad  {nullptr};  ///< pad for run/build info
+  };
+
+  // vector of plot pads
+  typedef std::vector<PlotPads> VPlotPads1D;
+  typedef std::vector<std::vector<PlotPads>> VPlotPads2D;
+  typedef std::vector<std::vector<std::vector<PlotPads>>> VPlotPads3D;
+
+  // ========================================================================
+  //! Helper struct to consolidate histogram and drawing options
+  // ========================================================================
+  struct HistAndOpts
+  {
+    TH1*        hist   {nullptr}; ///< histogram
+    std::string title  {""};      ///< histogram title
+    std::string titlex {""};      ///< x-axis title
+    std::string titley {""};      ///< y-axis title
+    std::string titlez {""};      ///< z-axis title
+    float       margin {0.25};    ///< right margin of pad
+    bool        logy   {false};   ///< make y axis log
+    bool        logz   {false};   ///< make z axis log
+  };
+
+  // vector of histogram and options
+  typedef std::vector<HistAndOpts> VHistAndOpts1D;
+
+}  // end JetDrawDefs namespace
+
+#endif

--- a/subsystems/jets/Makefile.am
+++ b/subsystems/jets/Makefile.am
@@ -21,7 +21,8 @@ libqadrawjet_la_LIBADD = \
 jetincludedir=$(pkgincludedir)/jet
 
 jetinclude_HEADERS = \
-  JetDraw.h 
+  JetDraw.h \
+  JetDrawDefs.h
 
 libqadrawjet_la_SOURCES = \
   JetDraw.cc 


### PR DESCRIPTION
This pull request merges work by @jamesjl3,  @mitrankova, and @ruse-traveler which fixes several typos in labels, sets log of axes correctly, and ensures that no more than 4 histograms are plotted per page. It also adds docstrings to several places.

## Changes
- [x] Flip-flopped axis labels on jet kinematic plots are now fixed
- [x] Relevant axes are made log in 1D, 2D plots now
- [x] Canvases are now split 90-10 between histograms and run info
- [x] DRY violations have been fixed in several places
- [x] Finish merging splitting components with >4 histograms into multiple pages
- [x] Empty histograms are now drawn when one is missing rather than throwing errors
- [x] Add docstrings to members, functions
- [x] Make spacing consistent 
- [x] Prefer std::string to char* where convenient 