### PR TITLE
Add skeleton of base drawer class

### DIFF
--- a/subsystems/jets/BaseJetDrawer.h
+++ b/subsystems/jets/BaseJetDrawer.h
@@ -1,0 +1,33 @@
+// Derek Anderson <ruse-traveler@github.com>
+
+#ifndef BASE_JET_DRAWER_H
+#define BASE_JET_DRAWER_H
+
+// ============================================================================
+//! Base class for jet QA components
+// ============================================================================
+/*! Base class to define common functionality across
+ *  the different components of the jet QA. Each
+ *  jet QA module should have a corresponding
+ *  "drawer" class inheriting from this one.
+ */
+class BaseJetDrawer
+{
+
+  protected:
+
+    /* TODO inheritable things will go here */
+
+  public:
+
+    /* TODO common interface things will go here */
+
+    // ------------------------------------------------------------------------
+    //! default ctor/dtor
+    // ------------------------------------------------------------------------
+    BaseJetDrawer()  {};
+    ~BaseJetDrawer() {};
+
+};  // end BaseJetDrawer
+
+#endif

--- a/subsystems/jets/Makefile.am
+++ b/subsystems/jets/Makefile.am
@@ -21,6 +21,7 @@ libqadrawjet_la_LIBADD = \
 jetincludedir=$(pkgincludedir)/jet
 
 jetinclude_HEADERS = \
+  BaseJetDrawer.h \
   JetDraw.h \
   JetDrawDefs.h
 


### PR DESCRIPTION
This PR refactors the existing `JetDraw` class to accommodate running both calorimeter and track jets, and adds new components introduced during the shutdown.

## To-Do
- [ ] Finish base drawer class
- [ ] Factor existing components into individual drawers
- [ ] Add drawers for new/track modules
  - [ ] Dijet QA
  - [ ] Photon Kinematics QA
  - [ ] Status map QA
  - [ ] Beam-background QA 
  - [ ] Track sum vs. jet QA
  - [ ] Tracks-in-jets QA
- [ ] Split `JetDraw` into `CaloJetDraw` and `TrackJetDraw` 