### PR TITLE
Micromegas offline qa improvements 4

### DIFF
--- a/subsystems/micromegas/MicromegasDraw.cc
+++ b/subsystems/micromegas/MicromegasDraw.cc
@@ -28,12 +28,6 @@
 namespace
 {
 
-  // maximum number of packets
-  static constexpr int m_npackets_active = 2;
-
-  //! number of fee boards
-  static constexpr int m_nfee_max = 26;
-
  //! make canvas editable in creator, and non-editable in destructor
   class CanvasEditor
   {
@@ -321,6 +315,9 @@ int MicromegasDraw::draw_bco_info()
     }
     legend_gl1->Draw();
 
+    gPad->Update();
+    draw_range( h_gl1, m_gl1_drop_rate_range );
+
   }
 
   // per packet BCO drop
@@ -366,6 +363,9 @@ int MicromegasDraw::draw_bco_info()
     legend_drop->SetBorderSize(0);
     legend_drop->SetFillStyle(0);
 
+    gPad->Update();
+    draw_range( h_drop, m_waveform_drop_rate_range );
+
     for (int i = 1; i <= h_drop->GetNbinsX(); ++i)
     {
       legend_drop->AddEntry((TObject*)0, Form("%s: %5.3g", h_drop->GetXaxis()->GetBinLabel(i), h_drop->GetBinContent(i)), "");
@@ -402,6 +402,9 @@ int MicromegasDraw::draw_bco_info()
     h_drop->Draw();
 
     gPad->SetLogy();
+
+    gPad->Update();
+    draw_range( h_drop, m_fee_waveform_drop_rate_range );
 
   }
 
@@ -501,6 +504,7 @@ int MicromegasDraw::draw_average_cluster_info()
     h_cluster_multiplicity->SetMaximum(10);
     h_cluster_multiplicity->DrawCopy("P");
     gPad->Update();
+
     draw_range( h_cluster_multiplicity, m_cluster_multiplicity_range );
     gPad->Update();
   }
@@ -619,7 +623,7 @@ int MicromegasDraw::draw_summary()
     std::unique_ptr<TH1> h_cluster_multiplicity( get_detector_average(h_cluster_multiplicity_raw, -0.5) );
     auto ngood = get_num_valid_detectors( h_cluster_multiplicity.get(), m_cluster_multiplicity_range );
     status_cluster_multiplicity = get_status( ngood, m_detector_cluster_mult_range );
-    text->AddText( Form("Number of detectors with cluster multiplicity in acceptable range: %i/%i - %s",ngood, m_nfee, status_string.at(status_cluster_multiplicity).c_str()));
+    text->AddText( Form("Number of detectors with cluster multiplicity in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_cluster_multiplicity).c_str()));
   }
 
   if( h_cluster_size_raw )
@@ -627,7 +631,7 @@ int MicromegasDraw::draw_summary()
     std::unique_ptr<TH1> h_cluster_size( get_detector_average(h_cluster_size_raw, -0.5) );
     auto ngood = get_num_valid_detectors( h_cluster_size.get(), m_cluster_size_range );
     status_cluster_size = get_status( ngood, m_detector_cluster_size_range );
-    text->AddText( Form("Number of detectors with cluster size in acceptable range: %i/%i - %s",ngood, m_nfee, status_string.at(status_cluster_size).c_str()));
+    text->AddText( Form("Number of detectors with cluster size in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_cluster_size).c_str()));
   }
 
   if( h_cluster_charge_raw )
@@ -635,7 +639,7 @@ int MicromegasDraw::draw_summary()
     std::unique_ptr<TH1> h_cluster_charge( get_detector_average(h_cluster_charge_raw) );
     auto ngood = get_num_valid_detectors( h_cluster_charge.get(), m_cluster_charge_range );
     status_cluster_charge = get_status( ngood, m_detector_cluster_charge_range );
-    text->AddText( Form("Number of detectors with cluster charge in acceptable range: %i/%i - %s",ngood,m_nfee,status_string.at(status_cluster_charge).c_str()));
+    text->AddText( Form("Number of detectors with cluster charge in acceptable range: %i/%i - %s",ngood,m_nfee_active,status_string.at(status_cluster_charge).c_str()));
   }
 
   if( h_cluster_count_ref&&h_cluster_count_found )
@@ -644,7 +648,7 @@ int MicromegasDraw::draw_summary()
     efficiency->Divide(h_cluster_count_found, h_cluster_count_ref, 1, 1, "B" );
     auto ngood = get_num_valid_detectors( efficiency.get(), m_efficiency_range );
     status_efficiency = get_status( ngood, m_detector_efficiency_range );
-    text->AddText( Form("Number of detectors with efficiency estimate in acceptable range: %i/%i - %s",ngood,m_nfee,status_string.at(status_efficiency).c_str()));
+    text->AddText( Form("Number of detectors with efficiency estimate in acceptable range: %i/%i - %s",ngood,m_nfee_active,status_string.at(status_efficiency).c_str()));
   }
 
   // global status

--- a/subsystems/micromegas/MicromegasDraw.cc
+++ b/subsystems/micromegas/MicromegasDraw.cc
@@ -691,6 +691,8 @@ int MicromegasDraw::draw_bco_summary()
     const auto ngood = get_num_valid_detectors( h_gl1.get(), m_gl1_drop_rate_range );
     status_gl1_drop_rate = get_status( ngood, m_packet_gl1_drop_rate_range );
     text->AddText( Form("Number of packets with gl1 drop rate in acceptable range: %i/%i - %s",ngood, m_npackets_active+1, status_string.at(status_gl1_drop_rate).c_str()));
+  } else {
+    text->AddText("Number of packets with gl1 drop rate in acceptable range: unknown (missing histograms)");
   }
 
   // per packet BCO drop
@@ -711,6 +713,8 @@ int MicromegasDraw::draw_bco_summary()
     const auto ngood = get_num_valid_detectors( h_drop.get(), m_waveform_drop_rate_range );
     status_waveform_drop_rate = get_status( ngood, m_packet_wf_drop_rate_range );
     text->AddText( Form("Number of packets with waveform drop rate in acceptable range: %i/%i - %s",ngood, m_npackets_active+1, status_string.at(status_waveform_drop_rate).c_str()));
+  } else {
+    text->AddText( "Number of packets with waveform drop rate in acceptable range: unknown (missing histograms)" );
   }
 
   // per FEE BCO drop
@@ -726,6 +730,8 @@ int MicromegasDraw::draw_bco_summary()
     const auto ngood = get_num_valid_detectors( h_drop.get(), m_fee_waveform_drop_rate_range );
     status_fee_waveform_drop_rate = get_status( ngood, m_fee_wf_drop_rate_range );
     text->AddText( Form("Number of fee with waveform drop rate in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_fee_waveform_drop_rate).c_str()));
+  } else {
+    text->AddText( "Number of fee with waveform drop rate in acceptable range: unknown (missing histograms)" );
   }
 
   // global status
@@ -778,6 +784,8 @@ int MicromegasDraw::draw_summary()
     const auto ngood = get_num_valid_detectors( h_cluster_multiplicity.get(), m_cluster_multiplicity_range );
     status_cluster_multiplicity = get_status( ngood, m_detector_cluster_mult_range );
     text->AddText( Form("Number of detectors with cluster multiplicity in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_cluster_multiplicity).c_str()));
+  } else {
+    text->AddText("Number of detectors with cluster multiplicity in acceptable range: unknown (missing histograms)" );
   }
 
   if( h_cluster_size_raw )
@@ -786,6 +794,8 @@ int MicromegasDraw::draw_summary()
     const auto ngood = get_num_valid_detectors( h_cluster_size.get(), m_cluster_size_range );
     status_cluster_size = get_status( ngood, m_detector_cluster_size_range );
     text->AddText( Form("Number of detectors with cluster size in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_cluster_size).c_str()));
+  } else {
+    text->AddText( "Number of detectors with cluster size in acceptable range: unknown (missing histograms)" );
   }
 
   if( h_cluster_charge_raw )
@@ -794,6 +804,8 @@ int MicromegasDraw::draw_summary()
     const auto ngood = get_num_valid_detectors( h_cluster_charge.get(), m_cluster_charge_range );
     status_cluster_charge = get_status( ngood, m_detector_cluster_charge_range );
     text->AddText( Form("Number of detectors with cluster charge in acceptable range: %i/%i - %s",ngood,m_nfee_active,status_string.at(status_cluster_charge).c_str()));
+  } else {
+    text->AddText( "Number of detectors with cluster charge in acceptable range: unknown (missing histograms)" );
   }
 
   if( h_cluster_count_ref&&h_cluster_count_found )
@@ -803,6 +815,8 @@ int MicromegasDraw::draw_summary()
     const auto ngood = get_num_valid_detectors( efficiency.get(), m_efficiency_range );
     status_efficiency = get_status( ngood, m_detector_efficiency_range );
     text->AddText( Form("Number of detectors with efficiency estimate in acceptable range: %i/%i - %s",ngood,m_nfee_active,status_string.at(status_efficiency).c_str()));
+  } else {
+    text->AddText( "Number of detectors with efficiency estimate in acceptable range: unknown (missing histograms)" );
   }
 
   // global status

--- a/subsystems/micromegas/MicromegasDraw.cc
+++ b/subsystems/micromegas/MicromegasDraw.cc
@@ -297,6 +297,7 @@ TCanvas* MicromegasDraw::create_canvas(const std::string &name)
 
     auto cv = new TCanvas(name.c_str(), "TPOT BCO summary", -1, 0,xsize/1.2, ysize/1.2);
     gSystem->ProcessEvents();
+    cv->Divide(1,1);
     create_transparent_pad(name);
     cv->SetEditable(false);
     m_canvas.push_back( cv );
@@ -307,6 +308,7 @@ TCanvas* MicromegasDraw::create_canvas(const std::string &name)
 
     auto cv = new TCanvas(name.c_str(), "TPOT summary", -1, 0,xsize/1.2, ysize/1.2);
     gSystem->ProcessEvents();
+    cv->Divide(1,1);
     create_transparent_pad(name);
     cv->SetEditable(false);
     m_canvas.push_back( cv );
@@ -671,6 +673,7 @@ int MicromegasDraw::draw_bco_summary()
   auto cv = get_canvas("TPOT_BCO_SUMMARY" );
   CanvasEditor cv_edit(cv);
 
+  cv->cd(1);
   auto text = new TPaveText(0.1,0.1,0.9,0.9, "NDC" );
   text->SetFillColor(0);
   text->SetFillStyle(0);
@@ -760,6 +763,7 @@ int MicromegasDraw::draw_summary()
   auto cv = get_canvas("TPOT_SUMMARY" );
   CanvasEditor cv_edit(cv);
 
+  cv->cd(1);
   auto text = new TPaveText(0.1,0.1,0.9,0.9, "NDC" );
   text->SetFillColor(0);
   text->SetFillStyle(0);

--- a/subsystems/micromegas/MicromegasDraw.cc
+++ b/subsystems/micromegas/MicromegasDraw.cc
@@ -750,7 +750,7 @@ int MicromegasDraw::draw_bco_summary()
 
   // global status
   const auto status_global = get_combined_status({ status_gl1_drop_rate, status_waveform_drop_rate, status_fee_waveform_drop_rate});
-  text->AddText( Form("Overall run status (BCO): %s",status_string.at(status_global).c_str()))
+  text->AddText( Form("Overall status (BCO): %s",status_string.at(status_global).c_str()))
     ->SetTextColor(status_color.at(status_global));
 
   text->Draw();
@@ -844,7 +844,7 @@ int MicromegasDraw::draw_summary()
 
   // global status
   const auto status_global = get_combined_status({ status_cluster_multiplicity, status_cluster_size, status_cluster_charge, status_efficiency });
-  text->AddText( Form("Overall run status: %s",status_string.at(status_global).c_str()))
+  text->AddText( Form("Overall status: %s",status_string.at(status_global).c_str()))
     ->SetTextColor(status_color.at(status_global));
 
   text->Draw();

--- a/subsystems/micromegas/MicromegasDraw.cc
+++ b/subsystems/micromegas/MicromegasDraw.cc
@@ -133,6 +133,14 @@ namespace
     { Status::status_good, "good" }
   };
 
+  //! statis color
+  const std::map<Status,int> status_color = {
+    { Status::status_unknown, kRed+2 },
+    { Status::status_bad, kRed+2 },
+    { Status::status_questionable, kOrange+2 },
+    { Status::status_good, kGreen+2 }
+  };
+
   //! get status based on how many detectors are in acceptable range
   Status get_status( int n_detectors, const MicromegasDraw::detector_range_t acceptable_range )
   {
@@ -690,9 +698,11 @@ int MicromegasDraw::draw_bco_summary()
     h_gl1->SetBinContent(3,1.-double(h_gl1_raw->GetBinContent(4))/h_gl1_raw->GetBinContent(1));
     const auto ngood = get_num_valid_detectors( h_gl1.get(), m_gl1_drop_rate_range );
     status_gl1_drop_rate = get_status( ngood, m_packet_gl1_drop_rate_range );
-    text->AddText( Form("Number of packets with gl1 drop rate in acceptable range: %i/%i - %s",ngood, m_npackets_active+1, status_string.at(status_gl1_drop_rate).c_str()));
+    text->AddText( Form("Number of packets with gl1 drop rate in acceptable range: %i/%i - %s",ngood, m_npackets_active+1, status_string.at(status_gl1_drop_rate).c_str()))
+      ->SetTextColor(status_color.at(status_gl1_drop_rate));
   } else {
-    text->AddText("Number of packets with gl1 drop rate in acceptable range: unknown (missing histograms)");
+    text->AddText("Number of packets with gl1 drop rate in acceptable range: unknown (missing histograms)")
+      ->SetTextColor(status_color.at(status_gl1_drop_rate));
   }
 
   // per packet BCO drop
@@ -712,9 +722,11 @@ int MicromegasDraw::draw_bco_summary()
 
     const auto ngood = get_num_valid_detectors( h_drop.get(), m_waveform_drop_rate_range );
     status_waveform_drop_rate = get_status( ngood, m_packet_wf_drop_rate_range );
-    text->AddText( Form("Number of packets with waveform drop rate in acceptable range: %i/%i - %s",ngood, m_npackets_active+1, status_string.at(status_waveform_drop_rate).c_str()));
+    text->AddText( Form("Number of packets with waveform drop rate in acceptable range: %i/%i - %s",ngood, m_npackets_active+1, status_string.at(status_waveform_drop_rate).c_str()))
+      ->SetTextColor(status_color.at(status_waveform_drop_rate));
   } else {
-    text->AddText( "Number of packets with waveform drop rate in acceptable range: unknown (missing histograms)" );
+    text->AddText( "Number of packets with waveform drop rate in acceptable range: unknown (missing histograms)" )
+      ->SetTextColor(status_color.at(status_waveform_drop_rate));
   }
 
   // per FEE BCO drop
@@ -729,14 +741,17 @@ int MicromegasDraw::draw_bco_summary()
     }
     const auto ngood = get_num_valid_detectors( h_drop.get(), m_fee_waveform_drop_rate_range );
     status_fee_waveform_drop_rate = get_status( ngood, m_fee_wf_drop_rate_range );
-    text->AddText( Form("Number of fee with waveform drop rate in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_fee_waveform_drop_rate).c_str()));
+    text->AddText( Form("Number of fee with waveform drop rate in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_fee_waveform_drop_rate).c_str()))
+      ->SetTextColor(status_color.at(status_fee_waveform_drop_rate));
   } else {
-    text->AddText( "Number of fee with waveform drop rate in acceptable range: unknown (missing histograms)" );
+    text->AddText( "Number of fee with waveform drop rate in acceptable range: unknown (missing histograms)" )
+      ->SetTextColor(status_color.at(status_fee_waveform_drop_rate));
   }
 
   // global status
   const auto status_global = get_combined_status({ status_gl1_drop_rate, status_waveform_drop_rate, status_fee_waveform_drop_rate});
-  text->AddText( Form("Overall run status (BCO): %s",status_string.at(status_global).c_str()));
+  text->AddText( Form("Overall run status (BCO): %s",status_string.at(status_global).c_str()))
+    ->SetTextColor(status_color.at(status_global));
 
   text->Draw();
   cv->Update();
@@ -783,9 +798,11 @@ int MicromegasDraw::draw_summary()
     std::unique_ptr<TH1> h_cluster_multiplicity( get_detector_average(h_cluster_multiplicity_raw, -0.5) );
     const auto ngood = get_num_valid_detectors( h_cluster_multiplicity.get(), m_cluster_multiplicity_range );
     status_cluster_multiplicity = get_status( ngood, m_detector_cluster_mult_range );
-    text->AddText( Form("Number of detectors with cluster multiplicity in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_cluster_multiplicity).c_str()));
+    text->AddText( Form("Number of detectors with cluster multiplicity in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_cluster_multiplicity).c_str()))
+      ->SetTextColor(status_color.at(status_cluster_multiplicity));
   } else {
-    text->AddText("Number of detectors with cluster multiplicity in acceptable range: unknown (missing histograms)" );
+    text->AddText("Number of detectors with cluster multiplicity in acceptable range: unknown (missing histograms)" )
+      ->SetTextColor(status_color.at(status_cluster_multiplicity));
   }
 
   if( h_cluster_size_raw )
@@ -793,9 +810,11 @@ int MicromegasDraw::draw_summary()
     std::unique_ptr<TH1> h_cluster_size( get_detector_average(h_cluster_size_raw, -0.5) );
     const auto ngood = get_num_valid_detectors( h_cluster_size.get(), m_cluster_size_range );
     status_cluster_size = get_status( ngood, m_detector_cluster_size_range );
-    text->AddText( Form("Number of detectors with cluster size in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_cluster_size).c_str()));
+    text->AddText( Form("Number of detectors with cluster size in acceptable range: %i/%i - %s",ngood, m_nfee_active, status_string.at(status_cluster_size).c_str()))
+      ->SetTextColor(status_color.at(status_cluster_size));
   } else {
-    text->AddText( "Number of detectors with cluster size in acceptable range: unknown (missing histograms)" );
+    text->AddText( "Number of detectors with cluster size in acceptable range: unknown (missing histograms)" )
+      ->SetTextColor(status_color.at(status_cluster_size));
   }
 
   if( h_cluster_charge_raw )
@@ -803,9 +822,11 @@ int MicromegasDraw::draw_summary()
     std::unique_ptr<TH1> h_cluster_charge( get_detector_average(h_cluster_charge_raw) );
     const auto ngood = get_num_valid_detectors( h_cluster_charge.get(), m_cluster_charge_range );
     status_cluster_charge = get_status( ngood, m_detector_cluster_charge_range );
-    text->AddText( Form("Number of detectors with cluster charge in acceptable range: %i/%i - %s",ngood,m_nfee_active,status_string.at(status_cluster_charge).c_str()));
+    text->AddText( Form("Number of detectors with cluster charge in acceptable range: %i/%i - %s",ngood,m_nfee_active,status_string.at(status_cluster_charge).c_str()))
+      ->SetTextColor(status_color.at(status_cluster_charge));
   } else {
-    text->AddText( "Number of detectors with cluster charge in acceptable range: unknown (missing histograms)" );
+    text->AddText( "Number of detectors with cluster charge in acceptable range: unknown (missing histograms)" )
+      ->SetTextColor(status_color.at(status_cluster_charge));
   }
 
   if( h_cluster_count_ref&&h_cluster_count_found )
@@ -814,14 +835,17 @@ int MicromegasDraw::draw_summary()
     efficiency->Divide(h_cluster_count_found, h_cluster_count_ref, 1, 1, "B" );
     const auto ngood = get_num_valid_detectors( efficiency.get(), m_efficiency_range );
     status_efficiency = get_status( ngood, m_detector_efficiency_range );
-    text->AddText( Form("Number of detectors with efficiency estimate in acceptable range: %i/%i - %s",ngood,m_nfee_active,status_string.at(status_efficiency).c_str()));
+    text->AddText( Form("Number of detectors with efficiency estimate in acceptable range: %i/%i - %s",ngood,m_nfee_active,status_string.at(status_efficiency).c_str()))
+      ->SetTextColor(status_color.at(status_efficiency));
   } else {
-    text->AddText( "Number of detectors with efficiency estimate in acceptable range: unknown (missing histograms)" );
+    text->AddText( "Number of detectors with efficiency estimate in acceptable range: unknown (missing histograms)" )
+      ->SetTextColor(status_color.at(status_efficiency));
   }
 
   // global status
   const auto status_global = get_combined_status({ status_cluster_multiplicity, status_cluster_size, status_cluster_charge, status_efficiency });
-  text->AddText( Form("Overall run status: %s",status_string.at(status_global).c_str()));
+  text->AddText( Form("Overall run status: %s",status_string.at(status_global).c_str()))
+    ->SetTextColor(status_color.at(status_global));
 
   text->Draw();
   cv->Update();

--- a/subsystems/micromegas/MicromegasDraw.cc
+++ b/subsystems/micromegas/MicromegasDraw.cc
@@ -288,25 +288,26 @@ int MicromegasDraw::draw_bco_info()
     auto h_gl1= new TH1F("h_gl1", "Match Rate", m_npackets_active+1, 0, m_npackets_active+1);
     h_gl1->SetStats(0);
     h_gl1->GetXaxis()->SetTitle("Packet");
-    h_gl1->GetYaxis()->SetTitle("GL1 BCO Match Rate");
-    h_gl1->SetTitle("GL1 BCO Matching Rate by packet");
+    h_gl1->GetYaxis()->SetTitle("GL1 BCO drop rate");
+    h_gl1->SetTitle("GL1 BCO drop rate by packet");
 
     h_gl1->GetXaxis()->SetBinLabel(1, "5001");
     h_gl1->GetXaxis()->SetBinLabel(2, "5002");
     h_gl1->GetXaxis()->SetBinLabel(3, "all");
 
-    h_gl1->SetBinContent(3,double(h_gl1_raw->GetBinContent(4))/h_gl1_raw->GetBinContent(1));
-    h_gl1->SetBinContent(2,double(h_gl1_raw->GetBinContent(3))/h_gl1_raw->GetBinContent(1));
-    h_gl1->SetBinContent(1,double(h_gl1_raw->GetBinContent(2))/h_gl1_raw->GetBinContent(1));
+    h_gl1->SetBinContent(1,1.-double(h_gl1_raw->GetBinContent(2))/h_gl1_raw->GetBinContent(1));
+    h_gl1->SetBinContent(2,1.-double(h_gl1_raw->GetBinContent(3))/h_gl1_raw->GetBinContent(1));
+    h_gl1->SetBinContent(3,1.-double(h_gl1_raw->GetBinContent(4))/h_gl1_raw->GetBinContent(1));
 
     auto cv = get_canvas("TPOT_BCO");
     CanvasEditor cv_edit(cv);
     cv->cd(1);
-    h_gl1->SetMinimum(0);
+    h_gl1->SetMinimum(1e-5);
     h_gl1->SetMaximum(1.1);
     h_gl1->SetFillStyle(1001);
     h_gl1->SetFillColor(kYellow);
     h_gl1->Draw();
+    gPad->SetLogy();
 
     auto legend_gl1 = new TLegend(0.65, 0.6, 0.85, 0.84);
     legend_gl1->SetHeader("Values", "C");
@@ -316,7 +317,7 @@ int MicromegasDraw::draw_bco_info()
 
     for (int i = 1; i <= h_gl1->GetNbinsX(); ++i)
     {
-      legend_gl1->AddEntry((TObject*)0, Form("%s: %.4f", h_gl1->GetXaxis()->GetBinLabel(i), h_gl1->GetBinContent(i)), "");
+      legend_gl1->AddEntry((TObject*)0, Form("%s: %5.3g", h_gl1->GetXaxis()->GetBinLabel(i), h_gl1->GetBinContent(i)), "");
     }
     legend_gl1->Draw();
 
@@ -367,7 +368,7 @@ int MicromegasDraw::draw_bco_info()
 
     for (int i = 1; i <= h_drop->GetNbinsX(); ++i)
     {
-      legend_drop->AddEntry((TObject*)0, Form("%s: %.4f", h_drop->GetXaxis()->GetBinLabel(i), h_drop->GetBinContent(i)), "");
+      legend_drop->AddEntry((TObject*)0, Form("%s: %5.3g", h_drop->GetXaxis()->GetBinLabel(i), h_drop->GetBinContent(i)), "");
     }
     legend_drop->Draw();
   }

--- a/subsystems/micromegas/MicromegasDraw.h
+++ b/subsystems/micromegas/MicromegasDraw.h
@@ -122,6 +122,9 @@ class MicromegasDraw : public QADraw
   int draw_average_cluster_info();
 
   //! summary
+  int draw_bco_summary();
+
+  //! summary
   int draw_summary();
 
   //! canvases
@@ -137,7 +140,7 @@ class MicromegasDraw : public QADraw
   static constexpr int m_nfee_max = 26;
 
   //! acceptable gl1 drop rate
-  range_list_t m_gl1_drop_rate_range = range_list_t(m_npackets_active+1, {0, 0.05});
+  range_list_t m_gl1_drop_rate_range = range_list_t(m_npackets_active+1, {0, 0.01});
 
   //! acceptable numbers of good packets for g1l drop rate
   detector_range_t m_packet_gl1_drop_rate_range = {3,3};
@@ -149,7 +152,13 @@ class MicromegasDraw : public QADraw
   detector_range_t m_packet_wf_drop_rate_range = {3,3};
 
   //! acceptable per packet waveform drop rate
-  range_list_t m_fee_waveform_drop_rate_range = range_list_t(m_nfee_max, {0, 0.05});
+  range_list_t m_fee_waveform_drop_rate_range = {
+    {0, 0.05}, {0, 0.05}, {0, 0.00}, {0, 0.00}, {0, 0.00},
+    {0, 0.05}, {0, 0.05}, {0, 0.05}, {0, 0.05}, {0, 0.05},
+    {0, 0.00}, {0, 0.00}, {0, 0.05}, {0, 0.00}, {0, 0.05},
+    {0, 0.05}, {0, 0.00}, {0, 0.00}, {0, 0.05}, {0, 0.05},
+    {0, 0.00}, {0, 0.05}, {0, 0.00}, {0, 0.05}, {0, 0.05},
+    {0, 0.05} };
 
   //! acceptable numbers of good fee for waveform drop rate
   detector_range_t m_fee_wf_drop_rate_range = {8,13};

--- a/subsystems/micromegas/MicromegasDraw.h
+++ b/subsystems/micromegas/MicromegasDraw.h
@@ -131,7 +131,24 @@ class MicromegasDraw : public QADraw
   range_list_t m_cluster_multiplicity_range = range_list_t(16, {1.5,4});
 
   //! acceptable cluster size range
-  range_list_t m_cluster_size_range = range_list_t(16, {1.5,4});
+  range_list_t m_cluster_size_range = {
+    {2,4}, // SCOP
+    {2,4}, // SCIP
+    {2,4}, // NCIP
+    {2,4}, // NCOP
+    {2,4}, // SEIP
+    {2,4}, // NEIP
+    {2,4}, // SWIP
+    {2,4}, // NWIP
+    {1.5,3.5}, // SCOZ
+    {1.5,3.5}, // SCIZ
+    {1.5,3.5}, // NCIZ
+    {1.5,3.5}, // NCOZ
+    {1.5,3.5}, // SEIZ
+    {1.5,3.5}, // NEIZ
+    {1.5,3.5}, // SWIZ
+    {1.5,3.5}  // NWIZ
+  };
 
   //! acceptable cluster charge range
   range_list_t m_cluster_charge_range = range_list_t(16, {300,700});

--- a/subsystems/micromegas/MicromegasDraw.h
+++ b/subsystems/micromegas/MicromegasDraw.h
@@ -127,11 +127,38 @@ class MicromegasDraw : public QADraw
   //! canvases
   std::vector<TCanvas*> m_canvas;
 
+  //! number of active fee boards
+  static constexpr int m_nfee_active = 16;
+
+  // maximum number of packets
+  static constexpr int m_npackets_active = 2;
+
   //! number of fee boards
-  static constexpr int m_nfee = 16;
+  static constexpr int m_nfee_max = 26;
+
+  //! acceptable gl1 drop rate
+  range_list_t m_gl1_drop_rate_range = range_list_t(m_npackets_active+1, {0, 0.05});
+
+  //! acceptable numbers of good packets for g1l drop rate
+  detector_range_t m_packet_gl1_drop_rate_range = {3,3};
+
+  //! acceptable per packet waveform drop rate
+  range_list_t m_waveform_drop_rate_range = range_list_t(m_npackets_active+1, {0, 0.05});
+
+  //! acceptable numbers of good packets for waveform drop rate
+  detector_range_t m_packet_wf_drop_rate_range = {3,3};
+
+  //! acceptable per packet waveform drop rate
+  range_list_t m_fee_waveform_drop_rate_range = range_list_t(m_nfee_max, {0, 0.05});
+
+  //! acceptable numbers of good fee for waveform drop rate
+  detector_range_t m_fee_wf_drop_rate_range = {8,13};
 
   //! acceptable cluster multiplicity range
-  range_list_t m_cluster_multiplicity_range = range_list_t(m_nfee, {1.5,4});
+  range_list_t m_cluster_multiplicity_range = range_list_t(m_nfee_active, {1.5,4});
+
+  //! acceptable numbers of good detectors for cluster multiplicity
+  detector_range_t m_detector_cluster_mult_range = {7,13};
 
   //! acceptable cluster size range
   range_list_t m_cluster_size_range = {
@@ -153,8 +180,14 @@ class MicromegasDraw : public QADraw
     {1.5,3.5}  // NWIZ
   };
 
+  //! acceptable numbers of good detectors for cluster size
+  detector_range_t m_detector_cluster_size_range = {8,13};
+
   //! acceptable cluster charge range
-  range_list_t m_cluster_charge_range = range_list_t(m_nfee, {300,700});
+  range_list_t m_cluster_charge_range = range_list_t(m_nfee_active, {300,700});
+
+  //! acceptable numbers of good detectors for cluster charge
+  detector_range_t m_detector_cluster_charge_range = {8,13};
 
   //! acceptable efficiency range
   range_list_t m_efficiency_range =
@@ -177,9 +210,7 @@ class MicromegasDraw : public QADraw
     {0.6,1.0}  // NWIZ
   };
 
-  detector_range_t m_detector_cluster_mult_range = {7,13};
-  detector_range_t m_detector_cluster_size_range = {8,13};
-  detector_range_t m_detector_cluster_charge_range = {8,13};
+  //! acceptable numbers of good detectors for efficiency estimate
   detector_range_t m_detector_efficiency_range = {9,13};
 
 };

--- a/subsystems/micromegas/MicromegasDraw.h
+++ b/subsystems/micromegas/MicromegasDraw.h
@@ -127,8 +127,11 @@ class MicromegasDraw : public QADraw
   //! canvases
   std::vector<TCanvas*> m_canvas;
 
+  //! number of fee boards
+  static constexpr int m_nfee = 16;
+
   //! acceptable cluster multiplicity range
-  range_list_t m_cluster_multiplicity_range = range_list_t(16, {1.5,4});
+  range_list_t m_cluster_multiplicity_range = range_list_t(m_nfee, {1.5,4});
 
   //! acceptable cluster size range
   range_list_t m_cluster_size_range = {
@@ -151,7 +154,7 @@ class MicromegasDraw : public QADraw
   };
 
   //! acceptable cluster charge range
-  range_list_t m_cluster_charge_range = range_list_t(16, {300,700});
+  range_list_t m_cluster_charge_range = range_list_t(m_nfee, {300,700});
 
   //! acceptable efficiency range
   range_list_t m_efficiency_range =


### PR DESCRIPTION
Another round of improvements to TPOT offline QA to make it 'offline-shifter' ready
- added BCO page with acceptable ranges, 
- added BCO summary page
- added colors
Summary pages now look like this:
<img width="1660" height="916" alt="Screenshot_20250718_101904" src="https://github.com/user-attachments/assets/f13ccfd8-7f1d-496c-8617-b3f515df7a9f" />
<img width="1660" height="916" alt="Screenshot_20250718_101928" src="https://github.com/user-attachments/assets/a97dcc8c-a4a8-4e9a-855c-a4c045292b46" />

@osbornjd the MicromegasDraw module should also be added to the list of QA post-processing modules that run at the raw-data event decoding stage (the creation of raw hits). It should gracefully handle BCO histograms, and skip the missing Cluster QA histograms. Could you do that ? And tell me if there is anything I can do to help ?
