### PR TITLE
feat: file transfer QA

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,7 @@ AC_CONFIG_FILES([
   subsystems/calo/Makefile
   subsystems/calofitting/Makefile
   subsystems/example/Makefile
+  subsystems/filetransfer/Makefile
   subsystems/globalQA/Makefile
   subsystems/intt/Makefile
   subsystems/inttrawhit/Makefile

--- a/subsystems/Makefile.am
+++ b/subsystems/Makefile.am
@@ -5,6 +5,7 @@ include_HEADERS =
 ###USE ALPHABETICAL ORDER FOR MAKEFILE LIST
 
 SUBDIRS = \
+  filetransfer \
   bco \
   calo \
   calofitting \

--- a/subsystems/filetransfer/CheckFileTransfer.C
+++ b/subsystems/filetransfer/CheckFileTransfer.C
@@ -1,0 +1,322 @@
+#include "FileTransferUtils.C"
+
+R__LOAD_LIBRARY(libodbc++.so)
+
+//_________________________________________________________
+TH1* create_subsytems_histogram( const std::string& name, const std::string& title, const subsystem_info_t::list& subsystems = default_subsystems )
+{
+
+  const size_t count = subsystems.size();
+  auto h = new TH1F( name.c_str(), title.c_str(), count, 0, count );
+
+  // assign x axis bin labels
+  for( size_t i = 0; i < count; ++i )
+  { h->GetXaxis()->SetBinLabel( i+1, (subsystems[i].subsystem+"/"+subsystems[i].host).c_str()); }
+
+  h->GetYaxis()->SetTitle( "segment count" );
+
+  return h;
+}
+
+// start_date
+// date should look like
+// XXXX-XX-XX
+// as in 2025-07-21
+//
+//_________________________________________________________
+void CheckFileTransfer(const std::string& start_date="2025-07-21")
+{
+  // get list of runs
+  const auto runnumbers = DBUtils::get_runnumbers_from_db( start_date );
+  // const runnumber_set_t runnumbers = {69566, 69567, 69746,71251};
+
+  // map runnumber with missing subsystems
+  std::map<int, subsystem_info_t::list> missing;
+  std::map<int, subsystem_info_t::list> missing_first_segment;
+
+  // runnumbers with completes DB
+  runnumber_set_t incomplete_db_runs;
+  runnumber_set_t complete_db_runs;
+
+  // set to true to produce QA page
+  const bool generate_qa_page = true;
+
+  // set to true to verify if transfered files are effectively on disk
+  const bool check_db_consistency = false;
+  fileinfo_set_t inconsistent_files;
+
+  // files missing from DB
+  filename_set_t missing_files_from_db;
+
+  // loop over runnumbers
+  for( const auto runnumber: runnumbers )
+  {
+    if( verbosity )
+    { std::cout << "runnumber: " << runnumber << std::endl; }
+
+    // create histograms
+    std::unique_ptr<TH1> h_expected(create_subsytems_histogram( "h_expected", "total number of segments", default_subsystems ) );
+    std::unique_ptr<TH1> h_ref(create_subsytems_histogram( "h_ref", "total number of segments", default_subsystems ) );
+    std::unique_ptr<TH1> h_transfered(create_subsytems_histogram( "h_transfered", "transfered segments", default_subsystems ) );
+    std::unique_ptr<TH1> h_transfered_first_segment(create_subsytems_histogram( "h_first_segment_transfered", "first segment transfered", default_subsystems ) );
+
+    // counters
+    unsigned int n_segments_expected = 0;
+    unsigned int n_first_segment_expected = 0;
+
+    unsigned int n_segments_total = 0;
+    unsigned int n_first_segment_total = 0;
+
+    unsigned int n_segments_transfered = 0;
+    unsigned int n_first_segment_transfered = 0;
+
+    // loop over subsystems
+    for( size_t i = 0; i<default_subsystems.size(); ++i )
+    {
+      // get subsystem
+      const auto& subsystem = default_subsystems[i];
+
+      // get the files from database
+      const auto daqdb_files = DBUtils::get_files_from_db( {runnumber}, subsystem );
+      h_ref->Fill(i, daqdb_files.size());
+
+      if( verbosity )
+      { std::cout << "subsystem: " << subsystem << " files: " << daqdb_files << std::endl << std::endl; }
+
+      // do nothing if daqdb_files is empty
+      if( daqdb_files.empty() ) continue;
+
+      // get max segment and expected filenames
+      const auto max_segment = Utils::get_segment( std::max_element( daqdb_files.begin(), daqdb_files.end(),
+        []( const fileinfo_t& first, const fileinfo_t& second )
+        { return Utils::get_segment(first.filename) < Utils::get_segment(second.filename); } )->filename );
+      const auto expected_filenames = Utils::get_expected_filenames( runnumber, max_segment+1, subsystem );
+
+      n_segments_expected += expected_filenames.size();
+      n_first_segment_expected += std::count_if( expected_filenames.begin(), expected_filenames.end(),
+        []( const std::string& filename ) { return Utils::get_segment(filename)==0; } );
+
+      h_expected->Fill(i, expected_filenames.size());
+
+      // print
+      if( verbosity )
+      { std::cout << "subsystem: " << subsystem << " expected files: " << expected_filenames << std::endl << std::endl; }
+
+      // look for missing filenames in the database by comparing expected to daqdb files
+      std::copy_if( expected_filenames.begin(), expected_filenames.end(), std::inserter(missing_files_from_db,missing_files_from_db.end()),
+        [&daqdb_files](const std::string& filename ){
+          return std::find_if(daqdb_files.begin(),daqdb_files.end(), [&filename](const fileinfo_t& fileinfo)
+          { return Utils::get_local_filename(fileinfo.filename)==filename; } ) == daqdb_files.end(); });
+
+      // loop over files check if requested segments have been transfered
+      bool transferred = true;
+      bool transferred_first_segment = true;
+      for( const auto& file_info:daqdb_files )
+      {
+        const bool is_first_segment = (Utils::get_segment(file_info.filename) == 0);
+
+        // increment counters
+        ++n_segments_total;
+        if( is_first_segment ) { ++n_first_segment_total; }
+
+        if( check_db_consistency && file_info.in_sdcc )
+        {
+          const auto lustre_filename = Utils::get_lustre_filename( Utils::get_local_filename(file_info.filename), subsystem );
+          const bool consistent = filesystem::exists(lustre_filename);
+          if( !consistent ) inconsistent_files.insert( file_info );
+        }
+
+        // check sdcc transfer status
+        if( !file_info.in_sdcc )
+        {
+          transferred = false;
+          if( is_first_segment )
+          {
+            transferred_first_segment = false;
+          }
+        } else {
+
+          // fill histograms
+          h_transfered->Fill(i);
+          if( is_first_segment )
+          { h_transfered_first_segment->Fill(i); }
+
+          // increment counters
+          ++n_segments_transfered;
+          if( is_first_segment ) { ++n_first_segment_transfered; }
+
+        }
+
+      }
+
+      if(!transferred) { missing[runnumber].emplace_back(subsystem); }
+      if(!transferred_first_segment) { missing_first_segment[runnumber].emplace_back(subsystem); }
+
+    }
+
+    if( n_segments_total == n_segments_expected )
+    {
+      complete_db_runs.insert(runnumber);
+    } else {
+      incomplete_db_runs.insert(runnumber);
+    }
+
+    if( generate_qa_page )
+    {
+      // make canvas and save
+      std::unique_ptr<TCanvas> cv( new TCanvas( "cv", "cv", 1200, 1200 ) );
+      cv->Divide(1,2 );
+
+      // adjust pad dimensions
+      cv->GetPad(1)->SetPad(0, 0.3, 1, 1);
+      cv->GetPad(2)->SetPad(0, 0, 1, 0.3);
+
+      // status histogram
+      cv->cd(1);
+      h_expected->SetStats(0);
+      h_expected->SetTitle(Form( "File transfer status for run %i", runnumber ));
+      h_expected->SetFillStyle(3001);
+      h_expected->SetFillColor(kYellow-10);
+      h_expected->SetMinimum(0.5);
+      h_expected->GetXaxis()->SetLabelSize(0.03);
+      h_expected->Draw("hist");
+
+      h_ref->SetFillStyle(3001);
+      h_ref->SetFillColor(kYellow-9);
+      h_ref->Draw("hist same");
+
+      h_transfered->SetFillStyle(3001);
+      h_transfered->SetFillColor(kGreen-8);
+      h_transfered->Draw("hist same");
+
+      h_transfered_first_segment->SetFillStyle(3001);
+      h_transfered_first_segment->SetFillColor(kGreen-5);
+      h_transfered_first_segment->Draw("hist same");
+
+      // legend
+      auto legend = new TLegend( 0.7, 0.7, 0.95, 0.85, "", "NDC" );
+      legend->SetFillStyle(0);
+      legend->AddEntry( h_expected.get(), "expected files", "f" );
+      legend->AddEntry( h_ref.get(), "files in DB", "f" );
+      legend->AddEntry( h_transfered.get(), "transfered", "f" );
+      legend->AddEntry( h_transfered_first_segment.get(), "first segment transfered", "f" );
+      legend->Draw();
+
+      gPad->SetBottomMargin(0.15);
+      gPad->SetLogy();
+
+      // summary
+      cv->cd(2);
+      std::unique_ptr<TPaveText> text( new TPaveText(0.1,0.1,0.9,0.9, "NDC" ) );
+      text->SetFillColor(0);
+      text->SetFillStyle(0);
+      text->SetBorderSize(0);
+      text->SetTextAlign(11);
+
+      text->AddText( "File transfer summary:" );
+
+      if( n_segments_total == n_segments_expected )
+      {
+        text->AddText( Form("Number of files in db: %i, expected: %i - good",n_segments_total, n_segments_expected ))->SetTextColor(kGreen+1);
+      } else {
+        text->AddText( Form("Number of files in db: %i, expected: %i - bad",n_segments_total, n_segments_expected ))->SetTextColor(kRed+1);
+      }
+
+      if( n_first_segment_total == n_first_segment_expected )
+      {
+        text->AddText( Form("Number of first segment files in db: %i, expected: %i - good",n_first_segment_total, n_first_segment_expected ))->SetTextColor(kGreen+1);
+      } else {
+        text->AddText( Form("Number of first segment files in db: %i, expected: %i - bad",n_first_segment_total, n_first_segment_expected ))->SetTextColor(kRed+1);
+      }
+
+
+      if( n_segments_transfered == n_segments_total )
+      {
+        text->AddText( Form("Number of files transfered: %i/%i - good",n_segments_transfered,n_segments_total ))->SetTextColor(kGreen+1);
+      } else {
+        text->AddText( Form("Number of files transfered: %i/%i - bad",n_segments_transfered,n_segments_total ))->SetTextColor(kRed+1);
+      }
+
+      if( n_first_segment_transfered == n_first_segment_total )
+      {
+        text->AddText( Form("Number of first segment files transfered: %i/%i - good",n_first_segment_transfered,n_first_segment_total ))->SetTextColor(kGreen+1);
+      } else {
+        text->AddText( Form("Number of first segment files transfered: %i/%i - bad",n_first_segment_transfered,n_first_segment_total ))->SetTextColor(kRed+1);
+      }
+
+      text->Draw();
+
+      // save canvas
+      cv->SaveAs( Form("FileTransferQA_0_%i.png", runnumber));
+    }
+
+  }
+
+  // print summary
+  std::cout << std::endl;
+  std::cout << "start date: " << start_date << std::endl << std::endl;
+  std::cout << "runnumbers: " << runnumbers << std::endl << std::endl;
+
+  // list of runs for which the db seems complete
+  std::cout << "runs with complete db files: " << complete_db_runs << std::endl << std::endl;
+
+  // list of runs for which the db seems complete
+  std::cout << "runs with incomplete db files: " << incomplete_db_runs << std::endl << std::endl;
+
+  // get list of fully transfered runs
+  runnumber_set_t complete_runs;
+  std::copy_if( runnumbers.begin(), runnumbers.end(), std::inserter(complete_runs, complete_runs.end()),
+    [&missing]( const int& runnumber ) { return !missing.contains(runnumber); } );
+  std::cout << "complete runs (all segments): " << complete_runs << std::endl << std::endl;
+
+  // get list of incomplete runs
+  runnumber_set_t incomplete_runs;
+  std::copy_if( runnumbers.begin(), runnumbers.end(), std::inserter(incomplete_runs, incomplete_runs.end()),
+    [&missing]( const int& runnumber ) { return missing.contains(runnumber); } );
+  std::cout << "incomplete runs (all segments): " << incomplete_runs << std::endl << std::endl;
+
+  // get list of fully transfered runs (first segment)
+  runnumber_set_t complete_runs_first_segment;
+  std::copy_if( runnumbers.begin(), runnumbers.end(), std::inserter(complete_runs_first_segment, complete_runs_first_segment.end()),
+    [&missing_first_segment]( const int& runnumber ) { return !missing_first_segment.contains(runnumber); } );
+  std::cout << "Complete runs (first segment): " << complete_runs_first_segment << std::endl << std::endl;
+
+  // get list of incomplete runs (first segment)
+  runnumber_set_t incomplete_runs_first_segment;
+  std::copy_if( runnumbers.begin(), runnumbers.end(), std::inserter(incomplete_runs_first_segment, incomplete_runs_first_segment.end()),
+    [&missing_first_segment]( const int& runnumber ) { return missing_first_segment.contains(runnumber); } );
+  std::cout << "incomplete runs (first segment): " << incomplete_runs_first_segment << std::endl << std::endl;
+
+  // print subsystems for which segments are missing, for each run
+  if( verbosity )
+  {
+    std::cout << "subsystem for which there are missing segments: " << std::endl << std::endl;
+    for( const auto& [runnumber, subsystems]:missing )
+    {
+      std::cout << "runnumber: " << runnumber << " [";
+      for( const auto& subsystem:subsystems)
+      { std::cout << " " << subsystem.host; };
+      std::cout << "]" << std::endl;
+    }
+  }
+
+  // print subsystems for which segments are missing, for each run
+  if( verbosity )
+  {
+    std::cout << "subsystem for which there are missing first segments: " << std::endl << std::endl;
+    for( const auto& [runnumber, subsystems]:missing_first_segment )
+    {
+      std::cout << "runnumber: " << runnumber << " [";
+      for( const auto& subsystem:subsystems)
+      { std::cout << " " << subsystem.host; };
+      std::cout << "]" << std::endl;
+    }
+  }
+
+  // print files not found in the database
+  std::cout << "files missing from db: " << missing_files_from_db << std::endl << std::endl;
+
+  if( check_db_consistency )
+  { std::cout << "files marked as transfered but not found on lustre: " << inconsistent_files << std::endl << std::endl; }
+
+}

--- a/subsystems/filetransfer/CheckMissingFiles.C
+++ b/subsystems/filetransfer/CheckMissingFiles.C
@@ -1,0 +1,103 @@
+#include "FileTransferUtils.C"
+
+R__LOAD_LIBRARY(libodbc++.so)
+
+namespace RawDataCatalog
+{
+
+  //! database connection
+  std::unique_ptr<odbc::Connection> dbConnection;
+
+  //! connect to daq database
+  bool connect_db()
+  {
+    try
+    {
+      // dbConnection.reset( odbc::DriverManager::getConnection("daq", "", "") );
+      dbConnection.reset( odbc::DriverManager::getConnection("RawdataCatalog", "sphnxhpssdbmaster", "") );
+    }
+    catch (odbc::SQLException &e)
+    {
+      std::cerr << "connect_db - Database connection failed: " << e.getMessage() << std::endl;
+      return false;
+    }
+    return true;
+  }
+
+}
+
+// start_date
+// date should look like
+// XXXX-XX-XX
+// as in 2025-07-21
+//
+//_________________________________________________________
+void CheckMissingFiles(const std::string& start_date="2025-07-21")
+{
+  // get list of runs
+  const auto runnumbers = DBUtils::get_runnumbers_from_db( start_date );
+  // const runnumber_set_t runnumbers = {69746};
+
+  // files missing from DB
+  using filename_map_t = std::map<subsystem_info_t, filename_set_t>;
+  filename_map_t missing_files_from_db;
+
+  RawDataCatalog::connect_db();
+  return;
+  // loop over runnumbers
+  for( const auto runnumber: runnumbers )
+  {
+    std::cout << "runnumber: " << runnumber << std::endl;
+
+    // loop over subsystems
+    for( size_t i = 0; i<default_subsystems.size(); ++i )
+    {
+      // get subsystem
+      const auto& subsystem = default_subsystems[i];
+
+      // get the files from database
+      const auto daqdb_files = DBUtils::get_files_from_db( {runnumber}, subsystem );
+
+      if( verbosity )
+      { std::cout << "subsystem: " << subsystem << " files: " << daqdb_files << std::endl << std::endl; }
+
+      // do nothing if daqdb_files is empty
+      if( daqdb_files.empty() ) continue;
+
+      // get max segment and expected filenames
+      const auto max_segment = Utils::get_segment( std::max_element( daqdb_files.begin(), daqdb_files.end(),
+        []( const fileinfo_t& first, const fileinfo_t& second )
+        { return Utils::get_segment(first.filename) < Utils::get_segment(second.filename); } )->filename );
+      const auto expected_filenames = Utils::get_expected_filenames( runnumber, max_segment+1, subsystem );
+
+      // look for missing filenames in the database by comparing expected to daqdb files
+      for( const auto& filename:expected_filenames)
+      {
+        if( std::find_if(daqdb_files.begin(),daqdb_files.end(), [&filename](const fileinfo_t& fileinfo)
+          { return Utils::get_local_filename(fileinfo.filename)==filename; } ) == daqdb_files.end())
+        { missing_files_from_db[subsystem].insert( filename ); }
+      }
+
+    }
+
+  }
+
+  // print summary
+  std::cout << std::endl;
+  std::cout << "start date: " << start_date << std::endl << std::endl;
+
+  // print files not found in the database
+  for( const auto& [subsystem, filenames]:missing_files_from_db )
+  {
+    std::cout << "syubsystem: " << subsystem << " files missing from db: " << filenames << std::endl;
+
+    // loop over files, see if they exist at SDCC
+    for( const auto& filename:filenames )
+    {
+      const auto lustre_filename = Utils::get_lustre_filename( filename, subsystem );
+      const bool file_exists = filesystem::exists(lustre_filename);
+      std::cout << "lustre_filename: " << lustre_filename << " esists: " << file_exists << std::endl;
+    }
+  }
+
+}

--- a/subsystems/filetransfer/FileTransfer.cc
+++ b/subsystems/filetransfer/FileTransfer.cc
@@ -94,10 +94,10 @@ int runnumber = QADrawClient::instance()->RunNumber();
     { std::cout << "runnumber: " << runnumber << std::endl; }
 
     // create histograms
-    std::unique_ptr<TH1> h_expected(create_subsytems_histogram( "h_expected", "total number of segments", default_subsystems ) );
-    std::unique_ptr<TH1> h_ref(create_subsytems_histogram( "h_ref", "total number of segments", default_subsystems ) );
-    std::unique_ptr<TH1> h_transfered(create_subsytems_histogram( "h_transfered", "transfered segments", default_subsystems ) );
-    std::unique_ptr<TH1> h_transfered_first_segment(create_subsytems_histogram( "h_first_segment_transfered", "first segment transfered", default_subsystems ) );
+    TH1* h_expected = create_subsytems_histogram( "h_expected", "total number of segments", default_subsystems ) ;
+    TH1* h_ref = create_subsytems_histogram( "h_ref", "total number of segments", default_subsystems ) ;
+    TH1* h_transfered = create_subsytems_histogram( "h_transfered", "transfered segments", default_subsystems ) ;
+   TH1* h_transfered_first_segment = create_subsytems_histogram( "h_first_segment_transfered", "first segment transfered", default_subsystems ) ;
 
     // counters
     unsigned int n_segments_expected = 0;
@@ -199,19 +199,14 @@ int runnumber = QADrawClient::instance()->RunNumber();
     } else {
       incomplete_db_runs.insert(runnumber);
     }
-/*
-    m_h_expected = std::move(h_expected);
-    m_h_ref = std::move(h_ref);
-    m_h_transfered = std::move(h_transfered);
-    m_h_transfered_first_segment = std::move(h_transfered_first_segment);*/
 
 
  // make canvas and save
-      TC[0]->Divide(1,2 );
+      //TC[0]->Divide(1,2 );
 
       // adjust pad dimensions
-      TC[0]->GetPad(1)->SetPad(0, 0.3, 1, 1);
-      TC[0]->GetPad(2)->SetPad(0, 0, 1, 0.3);
+      //TC[0]->GetPad(1)->SetPad(0, 0.3, 1, 1);
+      //TC[0]->GetPad(2)->SetPad(0, 0, 1, 0.3);
 
       // status histogram
       Pad[0]->cd();
@@ -224,7 +219,7 @@ int runnumber = QADrawClient::instance()->RunNumber();
       h_expected->DrawCopy("hist");
 
       h_ref->SetFillStyle(3001);
-      h_ref->SetFillColor(kYellow-9);
+      h_ref->SetFillColor(kYellow-7);
       h_ref->DrawCopy("hist same");
 
       h_transfered->SetFillStyle(3001);
@@ -232,24 +227,26 @@ int runnumber = QADrawClient::instance()->RunNumber();
       h_transfered->DrawCopy("hist same");
 
       h_transfered_first_segment->SetFillStyle(3001);
-      h_transfered_first_segment->SetFillColor(kGreen-5);
+      h_transfered_first_segment->SetFillColor(kGreen+2);
       h_transfered_first_segment->DrawCopy("hist same");
 
       // legend
       auto legend = new TLegend( 0.7, 0.7, 0.95, 0.85, "", "NDC" );
       legend->SetFillStyle(0);
-      legend->AddEntry( h_expected.get(), "expected files", "f" );
-      legend->AddEntry( h_ref.get(), "files in DB", "f" );
-      legend->AddEntry( h_transfered.get(), "transfered", "f" );
-      legend->AddEntry( h_transfered_first_segment.get(), "first segment transfered", "f" );
+      legend->AddEntry( h_expected, "expected files", "f" );
+      legend->AddEntry( h_ref, "files in DB", "f" );
+      legend->AddEntry( h_transfered, "transfered", "f" );
+      legend->AddEntry( h_transfered_first_segment, "first segment transfered", "f" );
       legend->Draw();
 
-      gPad->SetBottomMargin(0.15);
-      gPad->SetLogy();
+      Pad[0]->SetBottomMargin(0.15);
+      Pad[0]->SetLeftMargin(0.1);
+      Pad[0]->SetRightMargin(0.03);
+      Pad[0]->SetLogy();
 
       // summary
       Pad[1]->cd();
-      std::unique_ptr<TPaveText> text( new TPaveText(0.1,0.1,0.9,0.9, "NDC" ) );
+      TPaveText* text = new TPaveText(0.1,0.1,0.9,0.9, "NDC" ) ;
       text->SetFillColor(0);
       text->SetFillStyle(0);
       text->SetBorderSize(0);
@@ -300,8 +297,8 @@ int FileTransfer::MakeCanvas(const std::string &name)
   {
     // xpos (-1) negative: do not draw menu bar
     TC[0] = new TCanvas(name.c_str(), "FileTransfers", -1, 0, (int) (xsize / 1.2), (int) (ysize / 1.2));
-    Pad[0] = new TPad("pad0", "filetransfer0", 0.05, 0.05, 0.47, 0.97, 0);
-    Pad[1] = new TPad("pad1", "filetransfer1", 0.52, 0.05, 0.95, 0.97, 0);
+    Pad[0] = new TPad("pad0", "filetransfer0", 0.01, 0.35, 0.99, 0.97, 0);
+    Pad[1] = new TPad("pad1", "filetransfer1", 0.05, 0.05, 0.95, 0.3, 0);
     Pad[0]->Draw();
     Pad[1]->Draw();
   }
@@ -313,9 +310,10 @@ int FileTransfer::DrawTransfer(const std::string & /*what*/)
 {
   MakeCanvas("filetransfer");
 
-  //TC[0]->Clear("D");
+  TC[0]->Clear("D");
   CheckFileTransfer();
-
+  Pad[0]->Update();
+  Pad[1]->Update();
   //TC[0]->Update();
   return 0;
 }

--- a/subsystems/filetransfer/FileTransfer.cc
+++ b/subsystems/filetransfer/FileTransfer.cc
@@ -1,0 +1,340 @@
+#include "FileTransfer.h"
+#include <qahtml/QADrawClient.h>
+#include <qahtml/QADrawDB.h>
+
+#include <TCanvas.h>
+#include <TDatime.h>
+#include <TGraphErrors.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TPad.h>
+#include <TProfile.h>
+#include <TROOT.h>
+#include <TStyle.h>
+#include <TSystem.h>
+#include <TLegend.h>
+#include <TPaveText.h>
+#include <TText.h>
+
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <filesystem>
+
+FileTransfer::FileTransfer(const std::string &name)
+  : QADraw(name)
+{
+  memset(TC, 0, sizeof(TC));
+  memset(Pad, 0, sizeof(Pad));
+  return;
+}
+
+FileTransfer::~FileTransfer()
+{
+  return;
+}
+
+int FileTransfer::Draw(const std::string &what)
+{
+  int iret = 0;
+  int idraw = 0;
+  
+
+  if (what == "ALL")
+  {
+    iret += DrawTransfer(what);
+    idraw++;
+  }
+  if (!idraw)
+  {
+    std::cout << " Unimplemented Drawing option: " << what << std::endl;
+    iret = -1;
+  }
+  return iret;
+}
+
+TH1* FileTransfer::create_subsytems_histogram( const std::string& name, const std::string& title, const subsystem_info_t::list& subsystems = default_subsystems )
+{
+
+  const size_t count = subsystems.size();
+  auto h = new TH1F( name.c_str(), title.c_str(), count, 0, count );
+
+  // assign x axis bin labels
+  for( size_t i = 0; i < count; ++i )
+  { h->GetXaxis()->SetBinLabel( i+1, (subsystems[i].subsystem+"/"+subsystems[i].host).c_str()); }
+
+  h->GetYaxis()->SetTitle( "segment count" );
+
+  return h;
+}
+
+void FileTransfer::CheckFileTransfer()
+{
+ // const runnumber_set_t runnumbers = {69566, 69567, 69746,71251};
+
+  // map runnumber with missing subsystems
+  std::map<int, subsystem_info_t::list> missing;
+  std::map<int, subsystem_info_t::list> missing_first_segment;
+
+  // runnumbers with completes DB
+  runnumber_set_t incomplete_db_runs;
+  runnumber_set_t complete_db_runs;
+
+  // set to true to verify if transfered files are effectively on disk
+  const bool check_db_consistency = false;
+  fileinfo_set_t inconsistent_files;
+
+  // files missing from DB
+  filename_set_t missing_files_from_db;
+
+  // loop over runnumbers
+int runnumber = QADrawClient::instance()->RunNumber();
+    if( verbosity )
+    { std::cout << "runnumber: " << runnumber << std::endl; }
+
+    // create histograms
+    std::unique_ptr<TH1> h_expected(create_subsytems_histogram( "h_expected", "total number of segments", default_subsystems ) );
+    std::unique_ptr<TH1> h_ref(create_subsytems_histogram( "h_ref", "total number of segments", default_subsystems ) );
+    std::unique_ptr<TH1> h_transfered(create_subsytems_histogram( "h_transfered", "transfered segments", default_subsystems ) );
+    std::unique_ptr<TH1> h_transfered_first_segment(create_subsytems_histogram( "h_first_segment_transfered", "first segment transfered", default_subsystems ) );
+
+    // counters
+    unsigned int n_segments_expected = 0;
+    unsigned int n_first_segment_expected = 0;
+
+    unsigned int n_segments_total = 0;
+    unsigned int n_first_segment_total = 0;
+
+    unsigned int n_segments_transfered = 0;
+    unsigned int n_first_segment_transfered = 0;
+
+    // loop over subsystems
+    for( size_t i = 0; i<default_subsystems.size(); ++i )
+    {
+      // get subsystem
+      const auto& subsystem = default_subsystems[i];
+
+      // get the files from database
+      const auto daqdb_files = DBUtils::get_files_from_db( {runnumber}, subsystem );
+      h_ref->Fill(i, daqdb_files.size());
+
+      if( verbosity )
+      { std::cout << "subsystem: " << subsystem << " files: " << daqdb_files << std::endl << std::endl; }
+
+      // do nothing if daqdb_files is empty
+      if( daqdb_files.empty() ) continue;
+
+      // get max segment and expected filenames
+      const auto max_segment = Utils::get_segment( std::max_element( daqdb_files.begin(), daqdb_files.end(),
+        []( const fileinfo_t& first, const fileinfo_t& second )
+        { return Utils::get_segment(first.filename) < Utils::get_segment(second.filename); } )->filename );
+      const auto expected_filenames = Utils::get_expected_filenames( runnumber, max_segment+1, subsystem );
+
+      n_segments_expected += expected_filenames.size();
+      n_first_segment_expected += std::count_if( expected_filenames.begin(), expected_filenames.end(),
+        []( const std::string& filename ) { return Utils::get_segment(filename)==0; } );
+
+      h_expected->Fill(i, expected_filenames.size());
+
+      // print
+      if( verbosity )
+      { std::cout << "subsystem: " << subsystem << " expected files: " << expected_filenames << std::endl << std::endl; }
+
+      // look for missing filenames in the database by comparing expected to daqdb files
+      std::copy_if( expected_filenames.begin(), expected_filenames.end(), std::inserter(missing_files_from_db,missing_files_from_db.end()),
+        [&daqdb_files](const std::string& filename ){
+          return std::find_if(daqdb_files.begin(),daqdb_files.end(), [&filename](const fileinfo_t& fileinfo)
+          { return Utils::get_local_filename(fileinfo.filename)==filename; } ) == daqdb_files.end(); });
+
+      // loop over files check if requested segments have been transfered
+      bool transferred = true;
+      bool transferred_first_segment = true;
+      for( const auto& file_info:daqdb_files )
+      {
+        const bool is_first_segment = (Utils::get_segment(file_info.filename) == 0);
+
+        // increment counters
+        ++n_segments_total;
+        if( is_first_segment ) { ++n_first_segment_total; }
+
+        if( check_db_consistency && file_info.in_sdcc )
+        {
+          const auto lustre_filename = Utils::get_lustre_filename( Utils::get_local_filename(file_info.filename), subsystem );
+          const bool consistent = std::filesystem::exists(lustre_filename);
+          if( !consistent ) inconsistent_files.insert( file_info );
+        }
+
+        // check sdcc transfer status
+        if( !file_info.in_sdcc )
+        {
+          transferred = false;
+          if( is_first_segment )
+          {
+            transferred_first_segment = false;
+          }
+        } else {
+
+          // fill histograms
+          h_transfered->Fill(i);
+          if( is_first_segment )
+          { h_transfered_first_segment->Fill(i); }
+
+          // increment counters
+          ++n_segments_transfered;
+          if( is_first_segment ) { ++n_first_segment_transfered; }
+
+        }
+
+      }
+
+      if(!transferred) { missing[runnumber].emplace_back(subsystem); }
+      if(!transferred_first_segment) { missing_first_segment[runnumber].emplace_back(subsystem); }
+
+    }
+
+    if( n_segments_total == n_segments_expected )
+    {
+      complete_db_runs.insert(runnumber);
+    } else {
+      incomplete_db_runs.insert(runnumber);
+    }
+/*
+    m_h_expected = std::move(h_expected);
+    m_h_ref = std::move(h_ref);
+    m_h_transfered = std::move(h_transfered);
+    m_h_transfered_first_segment = std::move(h_transfered_first_segment);*/
+
+
+ // make canvas and save
+      TC[0]->Divide(1,2 );
+
+      // adjust pad dimensions
+      TC[0]->GetPad(1)->SetPad(0, 0.3, 1, 1);
+      TC[0]->GetPad(2)->SetPad(0, 0, 1, 0.3);
+
+      // status histogram
+      Pad[0]->cd();
+      h_expected->SetStats(0);
+      h_expected->SetTitle(Form( "File transfer status for run %i", runnumber ));
+      h_expected->SetFillStyle(3001);
+      h_expected->SetFillColor(kYellow-10);
+      h_expected->SetMinimum(0.5);
+      h_expected->GetXaxis()->SetLabelSize(0.03);
+      h_expected->DrawCopy("hist");
+
+      h_ref->SetFillStyle(3001);
+      h_ref->SetFillColor(kYellow-9);
+      h_ref->DrawCopy("hist same");
+
+      h_transfered->SetFillStyle(3001);
+      h_transfered->SetFillColor(kGreen-8);
+      h_transfered->DrawCopy("hist same");
+
+      h_transfered_first_segment->SetFillStyle(3001);
+      h_transfered_first_segment->SetFillColor(kGreen-5);
+      h_transfered_first_segment->DrawCopy("hist same");
+
+      // legend
+      auto legend = new TLegend( 0.7, 0.7, 0.95, 0.85, "", "NDC" );
+      legend->SetFillStyle(0);
+      legend->AddEntry( h_expected.get(), "expected files", "f" );
+      legend->AddEntry( h_ref.get(), "files in DB", "f" );
+      legend->AddEntry( h_transfered.get(), "transfered", "f" );
+      legend->AddEntry( h_transfered_first_segment.get(), "first segment transfered", "f" );
+      legend->Draw();
+
+      gPad->SetBottomMargin(0.15);
+      gPad->SetLogy();
+
+      // summary
+      Pad[1]->cd();
+      std::unique_ptr<TPaveText> text( new TPaveText(0.1,0.1,0.9,0.9, "NDC" ) );
+      text->SetFillColor(0);
+      text->SetFillStyle(0);
+      text->SetBorderSize(0);
+      text->SetTextAlign(11);
+
+      text->AddText( "File transfer summary:" );
+
+      if( n_segments_total == n_segments_expected )
+      {
+        text->AddText( Form("Number of files in db: %i, expected: %i - good",n_segments_total, n_segments_expected ))->SetTextColor(kGreen+1);
+      } else {
+        text->AddText( Form("Number of files in db: %i, expected: %i - bad",n_segments_total, n_segments_expected ))->SetTextColor(kRed+1);
+      }
+
+      if( n_first_segment_total == n_first_segment_expected )
+      {
+        text->AddText( Form("Number of first segment files in db: %i, expected: %i - good",n_first_segment_total, n_first_segment_expected ))->SetTextColor(kGreen+1);
+      } else {
+        text->AddText( Form("Number of first segment files in db: %i, expected: %i - bad",n_first_segment_total, n_first_segment_expected ))->SetTextColor(kRed+1);
+      }
+
+
+      if( n_segments_transfered == n_segments_total )
+      {
+        text->AddText( Form("Number of files transfered: %i/%i - good",n_segments_transfered,n_segments_total ))->SetTextColor(kGreen+1);
+      } else {
+        text->AddText( Form("Number of files transfered: %i/%i - bad",n_segments_transfered,n_segments_total ))->SetTextColor(kRed+1);
+      }
+
+      if( n_first_segment_transfered == n_first_segment_total )
+      {
+        text->AddText( Form("Number of first segment files transfered: %i/%i - good",n_first_segment_transfered,n_first_segment_total ))->SetTextColor(kGreen+1);
+      } else {
+
+        text->AddText( Form("Number of first segment files transfered: %i/%i - bad",n_first_segment_transfered,n_first_segment_total ))->SetTextColor(kRed+1);
+      }
+
+      text->Draw();
+
+
+}
+int FileTransfer::MakeCanvas(const std::string &name)
+{
+  QADrawClient *cl = QADrawClient::instance();
+  int xsize = cl->GetDisplaySizeX();
+  int ysize = cl->GetDisplaySizeY();
+  if (name == "filetransfer")
+  {
+    // xpos (-1) negative: do not draw menu bar
+    TC[0] = new TCanvas(name.c_str(), "FileTransfers", -1, 0, (int) (xsize / 1.2), (int) (ysize / 1.2));
+    Pad[0] = new TPad("pad0", "filetransfer0", 0.05, 0.05, 0.47, 0.97, 0);
+    Pad[1] = new TPad("pad1", "filetransfer1", 0.52, 0.05, 0.95, 0.97, 0);
+    Pad[0]->Draw();
+    Pad[1]->Draw();
+  }
+
+  return 0;
+}
+
+int FileTransfer::DrawTransfer(const std::string & /*what*/)
+{
+  MakeCanvas("filetransfer");
+
+  //TC[0]->Clear("D");
+  CheckFileTransfer();
+
+  //TC[0]->Update();
+  return 0;
+}
+
+
+int FileTransfer::MakeHtml(const std::string &what)
+{
+  int iret = Draw(what);
+  if (iret)  // on error no html output please
+  {
+    return iret;
+  }
+
+  QADrawClient *cl = QADrawClient::instance();
+
+  // Register the 1st canvas png file to the menu and produces the png file.
+  std::string pngfile = cl->htmlRegisterPage(*this, "FileTransfer", "0", "png");
+  cl->CanvasToPng(TC[0], pngfile);
+
+  return 0;
+}
+

--- a/subsystems/filetransfer/FileTransfer.h
+++ b/subsystems/filetransfer/FileTransfer.h
@@ -34,7 +34,6 @@ class FileTransfer : public QADraw
   TPad *transparent[1]{};
   TPad *Pad[4]{};
   int verbosity = 0;
-  std::unique_ptr<TH1> m_h_expected, m_h_ref, m_h_transfered, m_h_transfered_first_segment;
 };
 
 #endif

--- a/subsystems/filetransfer/FileTransfer.h
+++ b/subsystems/filetransfer/FileTransfer.h
@@ -1,0 +1,40 @@
+#ifndef FILETRANSFER_H__
+#define FILETRANSFER_H__
+
+#include <qahtml/QADraw.h>
+#include <memory>
+#include <vector>
+#include <iostream>
+
+#include "FileTransferUtils.h"
+
+class QADrawDB;
+class QADrawDBVar;
+class TCanvas;
+class TGraphErrors;
+class TPad;
+class TH1;
+
+class FileTransfer : public QADraw
+{
+ public:
+  FileTransfer(const std::string &name = "FileTransferQA");
+  ~FileTransfer() override;
+
+  int Draw(const std::string &what = "ALL") override;
+  int MakeHtml(const std::string &what = "ALL") override;
+
+ protected:
+  int MakeCanvas(const std::string &name);
+  int DrawTransfer(const std::string &what = "ALL");
+  void CheckFileTransfer();
+    TH1* create_subsytems_histogram( const std::string& name, const std::string& title, const subsystem_info_t::list& subsystems) ; 
+
+  TCanvas *TC[1]{};
+  TPad *transparent[1]{};
+  TPad *Pad[4]{};
+  int verbosity = 0;
+  std::unique_ptr<TH1> m_h_expected, m_h_ref, m_h_transfered, m_h_transfered_first_segment;
+};
+
+#endif

--- a/subsystems/filetransfer/FileTransferUtils.h
+++ b/subsystems/filetransfer/FileTransferUtils.h
@@ -1,0 +1,611 @@
+#ifndef FileTransferUtil_C
+#define FileTransferUtil_C
+
+#include <odbc++/connection.h>
+#include <odbc++/drivermanager.h>
+#include <odbc++/resultset.h>
+#include <odbc++/statement.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <set>
+#include <string>
+#include <iostream>
+#include <regex>
+
+#include <boost/format.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
+
+//! subsystem characterization, used for locating files on disk, db, etc.
+struct subsystem_info_t
+{
+  //! constructor
+  subsystem_info_t() = default;
+
+  //! constructor
+  subsystem_info_t( const std::string& _path, const std::string& _subsystem, const std::string& _host ):
+    path( _path ),
+    subsystem( _subsystem ),
+    host( _host )
+  {}
+
+  std::string path;
+  std::string subsystem;
+  std::string host;
+
+  using list = std::vector<subsystem_info_t>;
+};
+
+//! three-way operator for subsystem_info_t
+auto operator <=> (const subsystem_info_t& lhs, const subsystem_info_t& rhs )
+{
+  if( lhs.path != rhs.path ) return lhs.path <=> rhs.path;
+  else if( lhs.subsystem != rhs.subsystem ) return lhs.subsystem <=> rhs.subsystem;
+  else return lhs.host <=> rhs.host;
+}
+
+//! streamer for subsystem_info_t
+std::ostream& operator << (std::ostream& o, const subsystem_info_t& subsystem )
+{
+  o << "{" << subsystem.path << ", " << subsystem.subsystem << ", " << subsystem.host << "}";
+  return o;
+}
+
+// hardcoded list of all tracking subsystems
+static const subsystem_info_t::list default_subsystems =
+{
+  // TPC subsystems
+  {"tpc", "TPC", "ebdc00_0" },
+  {"tpc", "TPC", "ebdc01_0" },
+  {"tpc", "TPC", "ebdc02_0" },
+  {"tpc", "TPC", "ebdc03_0" },
+  {"tpc", "TPC", "ebdc04_0" },
+  {"tpc", "TPC", "ebdc05_0" },
+  {"tpc", "TPC", "ebdc06_0" },
+  {"tpc", "TPC", "ebdc07_0" },
+  {"tpc", "TPC", "ebdc08_0" },
+  {"tpc", "TPC", "ebdc09_0" },
+  {"tpc", "TPC", "ebdc10_0" },
+  {"tpc", "TPC", "ebdc11_0" },
+  {"tpc", "TPC", "ebdc12_0" },
+  {"tpc", "TPC", "ebdc13_0" },
+  {"tpc", "TPC", "ebdc14_0" },
+  {"tpc", "TPC", "ebdc15_0" },
+  {"tpc", "TPC", "ebdc16_0" },
+  {"tpc", "TPC", "ebdc17_0" },
+  {"tpc", "TPC", "ebdc18_0" },
+  {"tpc", "TPC", "ebdc19_0" },
+  {"tpc", "TPC", "ebdc20_0" },
+  {"tpc", "TPC", "ebdc21_0" },
+  {"tpc", "TPC", "ebdc22_0" },
+  {"tpc", "TPC", "ebdc23_0" },
+
+  // TPC subsystems
+  {"tpc", "TPC", "ebdc00_1" },
+  {"tpc", "TPC", "ebdc01_1" },
+  {"tpc", "TPC", "ebdc02_1" },
+  {"tpc", "TPC", "ebdc03_1" },
+  {"tpc", "TPC", "ebdc04_1" },
+  {"tpc", "TPC", "ebdc05_1" },
+  {"tpc", "TPC", "ebdc06_1" },
+  {"tpc", "TPC", "ebdc07_1" },
+  {"tpc", "TPC", "ebdc08_1" },
+  {"tpc", "TPC", "ebdc09_1" },
+  {"tpc", "TPC", "ebdc10_1" },
+  {"tpc", "TPC", "ebdc11_1" },
+  {"tpc", "TPC", "ebdc12_1" },
+  {"tpc", "TPC", "ebdc13_1" },
+  {"tpc", "TPC", "ebdc14_1" },
+  {"tpc", "TPC", "ebdc15_1" },
+  {"tpc", "TPC", "ebdc16_1" },
+  {"tpc", "TPC", "ebdc17_1" },
+  {"tpc", "TPC", "ebdc18_1" },
+  {"tpc", "TPC", "ebdc19_1" },
+  {"tpc", "TPC", "ebdc20_1" },
+  {"tpc", "TPC", "ebdc21_1" },
+  {"tpc", "TPC", "ebdc22_1" },
+  {"tpc", "TPC", "ebdc23_1" },
+
+  // TPOT subsystems
+  {"TPOT", "TPOT", "ebdc39" },
+
+  // INTT subsystem
+  {"INTT", "INTT", "intt0" },
+  {"INTT", "INTT", "intt1" },
+  {"INTT", "INTT", "intt2" },
+  {"INTT", "INTT", "intt3" },
+  {"INTT", "INTT", "intt4" },
+  {"INTT", "INTT", "intt5" },
+  {"INTT", "INTT", "intt6" },
+  {"INTT", "INTT", "intt7" },
+
+  // MVTX subsystems
+  {"MVTX", "MVTX", "mvtx0" },
+  {"MVTX", "MVTX", "mvtx1" },
+  {"MVTX", "MVTX", "mvtx2" },
+  {"MVTX", "MVTX", "mvtx3" },
+  {"MVTX", "MVTX", "mvtx4" },
+  {"MVTX", "MVTX", "mvtx5" },
+
+  // EMCAL
+  {"emcal", "EMCAL", "seb00" },
+  {"emcal", "EMCAL", "seb01" },
+  {"emcal", "EMCAL", "seb02" },
+  {"emcal", "EMCAL", "seb03" },
+  {"emcal", "EMCAL", "seb04" },
+  {"emcal", "EMCAL", "seb05" },
+  {"emcal", "EMCAL", "seb06" },
+  {"emcal", "EMCAL", "seb07" },
+  {"emcal", "EMCAL", "seb08" },
+  {"emcal", "EMCAL", "seb09" },
+  {"emcal", "EMCAL", "seb10" },
+  {"emcal", "EMCAL", "seb11" },
+  {"emcal", "EMCAL", "seb12" },
+  {"emcal", "EMCAL", "seb13" },
+  {"emcal", "EMCAL", "seb14" },
+  {"emcal", "EMCAL", "seb15" },
+
+  // HCAL
+  {"HCal", "HCAL", "seb16" },
+  {"HCal", "HCAL", "seb17" },
+
+  // MBD
+  {"mbd", "MBD", "seb18" },
+
+  // ZDC
+  {"ZDC", "ZDC", "seb20" },
+
+  // GL1
+  {"GL1", "GL1", "gl1daq" }
+};
+
+//! file information (from DB)
+struct fileinfo_t
+{
+  std::string filename;
+  bool in_hpss = false;
+  bool in_sdcc = false;
+};
+
+//! three-way operator for fileinfo_t
+auto operator <=> (const fileinfo_t& lhs, const fileinfo_t& rhs )
+{
+  if( lhs.filename != rhs.filename ) return lhs.filename <=> rhs.filename;
+  else if( lhs.in_hpss != rhs.in_hpss ) return lhs.in_hpss <=> rhs.in_hpss;
+  else return lhs.in_sdcc <=> rhs.in_sdcc;
+}
+
+//! streamer
+std::ostream& operator << (std::ostream& o, const fileinfo_t& fileinfo )
+{
+  o << fileinfo.filename << " in_hpss: " << fileinfo.in_hpss << " in_sdcc: " << fileinfo.in_sdcc;
+  return o;
+}
+
+using runnumber_set_t = std::set<int>;
+using filename_set_t = std::set<std::string>;
+using fileinfo_set_t = std::set<fileinfo_t>;
+
+//! default subsystem
+subsystem_info_t default_subsystem( "TPOT", "TPOT", "ebdc39" );
+std::string default_runtype = "physics";
+
+//! generic streamer for std::set
+template<class T>
+  std::ostream& operator << (std::ostream& o, const std::set<T>& input )
+{
+  if( input.empty() ) o << "{}";
+  else
+  {
+
+    o << "[" << input.size() << "] { " << std::endl;
+    for( const auto& i:input )
+    { o << "  " << i << std::endl; }
+    o << "}";
+  }
+  return o;
+}
+
+//! specialized streamer for runnumbers
+template<>
+  std::ostream& operator << (std::ostream& o, const std::set<int>& input )
+{
+  static constexpr int maxcount = 10;
+  if( input.empty() ) o << "{}";
+  else
+  {
+
+    o << "[" << input.size() << "] { ";
+
+    if( input.size() >= maxcount ) { std::cout << std::endl; }
+
+    int counter = 0;
+    for( const auto& i:input )
+    {
+
+      if( counter > 0 ) { o << ", "; }
+      o << i;
+
+      if( ++counter == maxcount )
+      {
+        counter =0;
+        o << std::endl;
+      }
+    }
+    o << " }";
+  }
+  return o;
+}
+
+// verbosity
+static constexpr int verbosity = 0;
+
+namespace DBUtils
+{
+
+  //! database connection
+  std::unique_ptr<odbc::Connection> dbConnection;
+
+  //! connect to daq database
+  bool connect_db()
+  {
+    try
+    {
+      dbConnection.reset( odbc::DriverManager::getConnection("daq", "", "") );
+    }
+    catch (odbc::SQLException &e)
+    {
+      std::cerr << "connect_db - Database connection failed: " << e.getMessage() << std::endl;
+      return false;
+    }
+    return true;
+  }
+
+  //_________________________________________________________
+  //! list all runnumbers from DB after a given timestamp
+  runnumber_set_t get_runnumbers_from_db( const std::string& timestamp, const std::string& runtype = default_runtype )
+  {
+    if( !(dbConnection || connect_db()) )
+    {
+      std::cout << "get_runnumbers_from_db - cannot connect to db" << std::endl;
+      return {};
+    }
+
+    std::unique_ptr<odbc::Statement> stmt( dbConnection->createStatement() );
+
+    // get run of type runtype, with length > 5 minutes and found in DB since timestamp
+    const std::string sql =
+      "SELECT runnumber "
+      "FROM run "
+      "WHERE runtype='"+runtype+"' "
+      "AND EXTRACT(EPOCH FROM (ertimestamp - brtimestamp)) > 300 " // five minute runs
+      "AND brtimestamp>='"+timestamp+"';";
+
+    runnumber_set_t runnumbers;
+    std::unique_ptr<odbc::ResultSet> resultSet( stmt->executeQuery(sql) );
+    while( resultSet && resultSet->next() )
+    {
+      const auto runnumber = resultSet->getInt("runnumber");
+      if( runnumber > 0 ) { runnumbers.insert(runnumber); }
+    }
+
+    return runnumbers;
+  }
+
+  //_________________________________________________________
+  //! list all files matching selection from daq database
+  fileinfo_set_t get_files_from_db( const std::string& selection )
+  {
+    if( !(dbConnection || connect_db()) )
+    {
+      std::cout << "get_files_from_db - cannot connect to db" << std::endl;
+      return {};
+    }
+
+    fileinfo_set_t out;
+    std::unique_ptr<odbc::Statement> stmt( dbConnection->createStatement() );
+
+    // create request
+    const std::string sql =
+      "SELECT run.runnumber, filename, transferred_to_hpss,transferred_to_sdcc "
+      "FROM run,filelist "
+      "WHERE run.runnumber=filelist.runnumber "
+      "AND " + selection + ";";
+
+    // request
+    std::unique_ptr<odbc::ResultSet> resultSet( stmt->executeQuery(sql) );
+    while( resultSet && resultSet->next() )
+    {
+      out.insert( {
+        .filename=resultSet->getString("filename"),
+          .in_hpss= resultSet->getBoolean("transferred_to_hpss"),
+          .in_sdcc= resultSet->getBoolean("transferred_to_sdcc") } );
+    }
+    return out;
+  }
+
+  //_________________________________________________________
+  //! list all files matching run number runtype and subsystem from daq database
+  fileinfo_set_t get_files_from_db(
+    const runnumber_set_t runnumbers = {},
+    const subsystem_info_t& subsystem = default_subsystem,
+    const std::string& runtype = default_runtype
+    )
+  {
+    fileinfo_set_t out;
+
+    if( runnumbers.empty() )
+    {
+
+      // create selection, adding host, runtype, and selecting only run3 Au-Au runs
+      const std::string selection =
+        "filename LIKE '%' || '"+subsystem.host+"' || '%' "
+        "AND runtype='"+runtype+"' "
+        "AND brtimestamp>'2025-01-01'";
+
+      out.merge( get_files_from_db(selection) );
+
+    } else {
+
+      // create selection, adding host, runtype, and selecting only run3 Au-Au runs
+      for( const auto& runnumber:runnumbers )
+      {
+        const std::string selection =
+          "run.runnumber = "+std::to_string(runnumber)+
+          " AND filename LIKE '%' || '"+subsystem.host+"' || '%';";
+        out.merge( get_files_from_db(selection) );
+      }
+
+    }
+
+    return out;
+  }
+}
+
+namespace Utils
+{
+
+  //_________________________________________________________
+  std::pair<int,int> get_run_segment( const std::string& filename )
+  {
+    // get segment number from filename
+    std::regex regex("-0*(\\d+)-(\\d+)\\.(evt|prdf)");
+    std::smatch match;
+    if( std::regex_search(filename, match, regex) )
+    {
+      return std::make_pair(std::stoi(match[1]),std::stoi(match[2]));
+    } else {
+      return {-1,-1};
+    }
+  }
+
+  //_________________________________________________________
+  int get_runnumber( const std::string& filename )
+  { return get_run_segment(filename).first; }
+
+  //_________________________________________________________
+  int get_segment( const std::string& filename )
+  { return get_run_segment(filename).second; }
+
+  //_________________________________________________________
+  // get raw data file extension for a given subsystem
+  std::string get_extension( const subsystem_info_t& subsystem = default_subsystem)
+  {
+    if( subsystem.subsystem == "TPC" || subsystem.subsystem == "TPOT" || subsystem.subsystem == "INTT" || subsystem.subsystem == "MVTX" )
+    {
+      return ".evt";
+    } else {
+      return ".prdf";
+    }
+  }
+
+  //_________________________________________________________
+  // get raw data base filename for a given subsystem
+  std::string get_basefilename( const subsystem_info_t& subsystem = default_subsystem, const std::string& runtype = default_runtype )
+  {
+    // base filename depends on the subsystem type unfortunately
+    if( subsystem.subsystem == "TPC" || subsystem.subsystem == "TPOT" )
+    {
+      return subsystem.subsystem+"_"+subsystem.host+"_"+runtype;
+    } else if( subsystem.subsystem == "GL1" ) {
+      return subsystem.subsystem+"_"+runtype+"_"+subsystem.host;
+    } else {
+      return runtype+"_"+subsystem.host;
+    }
+  }
+
+  //_________________________________________________________
+  // get sybststem from filename
+  subsystem_info_t get_subsystem( const std::string& filename )
+  {
+    {
+      // TPOT or TPC file
+      // TPC_ebdc23_1_physics-00069746-0036.evt
+      std::regex regex("/([A-Za-z]+)/[A-Za-z]+/([A-Za-z]+)_([A-Za-z0-9]+(:?_0|1)?)_");
+      std::smatch match;
+      if( std::regex_search(filename, match, regex) )
+      { return {match[1], match[2], match[3]}; }
+    }
+
+    {
+      // GL1
+      // /GL1/physics/GL1_physics_gl1daq-00069746-0000.evt
+      std::regex regex("/GL1/[A-Za-z]+/GL1_[A-Za-z]+_([A-Za-z0-9]+)-");
+      std::smatch match;
+      if( std::regex_search(filename, match, regex) )
+      { return {"GL1", "GL1", match[1]}; }
+    }
+
+    {
+      // all other subystems
+      std::regex regex("/([A-Za-z]+)/[A-Za-z]+/[A-Za-z]+_([A-Za-z0-9]+)-");
+      std::smatch match;
+      if( std::regex_search(filename, match, regex) )
+      { return {match[1], boost::to_upper_copy<std::string>(match[1]), match[2]}; }
+    }
+
+    return {};
+  }
+
+  //_________________________________________________________
+  //! list files from file descripor
+  filename_set_t read_files( const std::string& command )
+  {
+    filename_set_t out;
+    char line[512];
+    auto tmp = popen(command.c_str(), "r");
+    while( fgets( line, 512, tmp ) )
+    {
+      std::string filename;
+      std::istringstream(line) >> filename;
+      out.insert(filename);
+    }
+
+    // close on exit
+    pclose(tmp);
+
+    return out;
+  }
+
+  //_________________________________________________________
+  // get the 'local' filenames (with path removed) from input file
+  std::string get_local_filename( const std::string& source )
+  { return  std::filesystem::path(source).filename().string(); }
+
+  //_________________________________________________________
+  // get the 'local' filenames (with path removed) from fileinfo_t
+  std::string get_local_filename( const fileinfo_t& source )
+  { return  std::filesystem::path(source.filename).filename().string(); }
+
+  //_________________________________________________________
+  // get the 'local' filenames (with path removed) from input list
+  template< class T>
+  filename_set_t get_local_filenames( const std::set<T>& in )
+  {
+    filename_set_t out;
+    std::transform( in.begin(), in.end(), std::inserter(out, out.end() ),get_local_filename);
+    return out;
+  }
+
+  //_________________________________________________________
+  // get runnumbers from input list
+  runnumber_set_t get_runnumbers( const filename_set_t& in )
+  {
+
+    runnumber_set_t out;
+    std::transform( in.begin(), in.end(), std::inserter(out, out.end() ),
+      [](const std::string& filename )
+    { return get_run_segment(filename).first; });
+
+    return out;
+  }
+
+  //_________________________________________________________
+  /*
+  * generate the list of expected local filenames for a given runumber, subsystem and run type, up to a given segment number
+  * this is used to find holes in the recorded file lists
+  */
+  filename_set_t get_expected_filenames( int runnumber, int max_segment, const subsystem_info_t& subsystem = default_subsystem, const std::string& runtype = default_runtype )
+  {
+    filename_set_t out;
+    for( int segment=0; segment < max_segment; ++segment )
+    {
+      if( subsystem.subsystem == "TPC" || subsystem.subsystem == "TPOT" ) {
+        out.insert(subsystem.subsystem+"_"+subsystem.host+"_"+runtype+(boost::format("-%08i-%04i.evt")%runnumber%segment).str());
+      } else if( subsystem.subsystem == "GL1" ) {
+        out.insert(subsystem.subsystem+"_"+runtype+"_"+subsystem.host+(boost::format("-%08i-%04i.evt")%runnumber%segment).str());
+      } else {
+        out.insert(runtype+"_"+subsystem.host+(boost::format("-%08i-%04i%s")%runnumber%segment%get_extension(subsystem)).str());
+      }
+    }
+
+    return out;
+  }
+
+  //_________________________________________________________
+  /*
+   * Get full path on lustre from local filename, subsystem and run type
+   */
+  std::string get_lustre_filename( const std::string& local_filename,  const subsystem_info_t& subsystem = default_subsystem, const std::string& runtype = default_runtype )
+  {
+    static const std::string lustre_path( "/sphenix/lustre01/sphnxpro/physics/" );
+    return lustre_path+subsystem.path+"/"+runtype+"/"+local_filename;
+  }
+
+  //_________________________________________________________
+  //! list all files matching run numbers from bufferbox
+  filename_set_t get_files_from_bbox(
+    const runnumber_set_t runnumbers = {},
+    const subsystem_info_t& subsystem = default_subsystem,
+    const std::string& runtype = default_runtype
+    )
+  {
+    std::cout << "get_files_from_bbox" << std::endl;
+    filename_set_t out;
+
+    // generate ssh command
+    const std::string ssh_command = "ssh -Jcssh01.sdcc.bnl.gov sphnxpro@bbox0.sphenix.bnl.gov";
+
+    // generate path
+    const std::string path = "/bbox/bbox*/{a,b}/"+subsystem.path+"/"+runtype+"/";
+    if( runnumbers.empty() )
+    {
+
+      const std::string file_selection_pattern = path+"/"+get_basefilename(subsystem,runtype)+"-*-*"+get_extension(subsystem);
+      const std::string command = ssh_command+" -x 'ls "+file_selection_pattern+"'";
+      out.merge(read_files(command));
+
+    } else {
+
+      for( const auto& runnumber:runnumbers )
+      {
+        const std::string file_selection_pattern = path+"/"+get_basefilename(subsystem,runtype)+(boost::format("-%08i-*%s")%runnumber%get_extension(subsystem).c_str()).str();
+        const std::string command = ssh_command+" -x 'ls " + file_selection_pattern + "'";
+        out.merge(read_files(command));
+      }
+
+    }
+
+    return out;
+  }
+
+  //_________________________________________________________
+  //! list all files matching run numbers from bufferbox
+  filename_set_t get_files_from_lustre(
+    const runnumber_set_t runnumbers = {},
+    const subsystem_info_t& subsystem = default_subsystem,
+    const std::string& runtype = default_runtype
+    )
+  {
+    filename_set_t out;
+
+    // generate path
+    const std::string path = "/sphenix/lustre01/sphnxpro/physics/"+subsystem.path+"/"+runtype+"/";
+    if( runnumbers.empty() )
+    {
+
+      const std::string file_selection_pattern = path+"/"+get_basefilename(subsystem,runtype)+"-*-*"+get_extension(subsystem);
+      const std::string command = "ls " + file_selection_pattern;
+      out.merge(read_files(command));
+
+    } else {
+
+      for( const auto& runnumber:runnumbers )
+      {
+        const std::string file_selection_pattern = path+"/"+get_basefilename(subsystem,runtype)+(boost::format("-%08i-*%s")%runnumber%get_extension(subsystem).c_str()).str();
+
+        if( verbosity )
+        { std::cout << "get_files_from_lustre - file_selection_pattern: " << file_selection_pattern << std::endl; }
+
+        const std::string command = "ls " + file_selection_pattern;
+        out.merge(read_files(command));
+      }
+
+    }
+
+    return out;
+  }
+
+}
+
+#endif

--- a/subsystems/filetransfer/Makefile.am
+++ b/subsystems/filetransfer/Makefile.am
@@ -1,0 +1,45 @@
+AUTOMAKE_OPTIONS = foreign
+
+AM_CPPFLAGS = \
+  -I$(includedir) \
+  -I$(OPT_SPHENIX)/include \
+  -isystem$(OFFLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/rootmacros \
+  -isystem$(ROOTSYS)/include 
+
+lib_LTLIBRARIES = \
+  libqadrawfiletransfer.la
+
+libqadrawfiletransfer_la_LIBADD = \
+  -L$(libdir) \
+  -L$(OFFLINE_MAIN)/lib \
+  -lqadrawclient \
+  -lqadrawdb
+
+filetransferincludedir=$(pkgincludedir)/filetransfer
+
+filetransferinclude_HEADERS = \
+  FileTransferUtils.h \
+  FileTransfer.h
+
+libqadrawfiletransfer_la_SOURCES = \
+  FileTransfer.cc
+
+noinst_PROGRAMS = \
+  testexternals
+
+testexternals_SOURCES = \
+  testexternals.cc
+
+testexternals_LDADD = \
+  libqadrawfiletransfer.la
+
+testexternals.cc:
+	echo "//*** this is a generated file. Do not commit, do not edit" > $@
+	echo "int main()" >> $@
+	echo "{" >> $@
+	echo "  return 0;" >> $@
+	echo "}" >> $@
+
+clean-local:
+	rm -f $(BUILT_SOURCES)

--- a/subsystems/filetransfer/macros/draw_filetransfer.C
+++ b/subsystems/filetransfer/macros/draw_filetransfer.C
@@ -1,0 +1,20 @@
+#include <qahtml/QADrawClient.h>
+#include <filetransfer/FileTransfer.h>
+//#include <sPhenixStyle.C>
+R__LOAD_LIBRARY(libqadrawfiletransfer.so)
+
+void draw_filetransfer(const int runnumber) {
+  //SetsPhenixStyle();
+  QADrawClient *cl = QADrawClient::instance();
+  /* cl->Verbosity(1); */
+  QADraw *ex = new FileTransfer();
+  cl->registerDrawer(ex);
+
+  cl->RunNumber(runnumber);
+  /* cl->Print("ALL"); */
+  cl->MakeHtml();
+  delete cl;
+  std::cout << "Done" << std::endl;
+  gSystem->Exit(0);
+  return ;
+}


### PR DESCRIPTION
This takes @hupereir original file transfer macros (also added to this package) and adapts them to use QAhtml for the drawing. Some examples of tests can be found in the QAHtmlTest page. Next is to add it to the drawing scripts, which may take some massaging (or an entirely new script) since there are no histogram files needed for this special QA